### PR TITLE
[RCIAM-83] Added support for CoGroup Search both for Index and Select Views/Actions

### DIFF
--- a/app/Controller/CoGroupsController.php
+++ b/app/Controller/CoGroupsController.php
@@ -18,7 +18,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * @link          http://www.internet2.edu/comanage COmanage Project
  * @package       registry
  * @since         COmanage Registry v0.1
@@ -31,7 +31,7 @@ App::uses("StandardController", "Controller");
 class CoGroupsController extends StandardController {
   // Class name, used by Cake
   public $name = "CoGroups";
-  
+
   // Establish pagination parameters for HTML views
   public $paginate = array(
     'limit' => 25,
@@ -39,22 +39,21 @@ class CoGroupsController extends StandardController {
       'CoGroup.name' => 'asc'
     )
   );
-  
+
   // This controller needs a CO to be set
   public $requires_co = true;
-  
+
   public $delete_contains = array(
   );
-  
+
   public $edit_contains = array(
     'EmailListAdmin',
     'EmailListMember',
     'EmailListModerator'
   );
-  
-  public $view_contains = array(
-  );
-  
+
+  public $view_contains = array();
+
   /**
    * Callback to set relevant tab to open when redirecting to another page
    * - precondition:
@@ -81,13 +80,13 @@ class CoGroupsController extends StandardController {
    * @param  Array Current data
    * @return boolean true if dependency checks succeed, false otherwise.
    */
-  
+
   function checkDeleteDependencies($curdata) {
     $fn = "CoGroupsController@checkDeleteDependencies";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
     // It would be preferable to move this to beforeDelete, but ChangelogBehavior
     // prevents that since beforeDelete callbacks don't fire.
-    
+
     if(isset($curdata['CoGroup']['group_type'])
        && $curdata['CoGroup']['group_type'] != GroupEnum::Standard) {
       if($this->request->is('restful')) {
@@ -97,7 +96,7 @@ class CoGroupsController extends StandardController {
       }
       return false;
     }
-    
+
     return true;
   }
 
@@ -111,13 +110,13 @@ class CoGroupsController extends StandardController {
    * @param  Array Current data
    * @return boolean true if dependency checks succeed, false otherwise.
    */
-  
+
   function checkWriteDependencies($reqdata, $curdata = null) {
     $fn = "CoGroupsController@checkWriteDependencies";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
     if(!isset($curdata) || ($curdata['CoGroup']['name'] != $reqdata['CoGroup']['name'])) {
       // Disallow names beginning with 'admin' if the current user is not an admin.
-      
+
       if(!$this->viewVars['permissions']['admin']) {
         if($reqdata['CoGroup']['name'] == 'admin'
            || strncmp($reqdata['CoGroup']['name'], 'admin:', 6) == 0) {
@@ -126,11 +125,11 @@ class CoGroupsController extends StandardController {
           } else {
             $this->Flash->set(_txt('er.gr.res'), array('key' => 'error'));
           }
-          
+
           return false;
         }
       }
-      
+
       // Disallow names beginning with 'CO:', which are reserved.
       if(strncmp($reqdata['CoGroup']['name'], 'CO:', 3) == 0) {
         if($this->request->is('restful')) {
@@ -138,27 +137,27 @@ class CoGroupsController extends StandardController {
         } else {
           $this->Flash->set(_txt('er.gr.reserved'), array('key' => 'error'));
         }
-  
+
         return false;
       }
-      
+
       // Make sure name doesn't exist within this CO.
-      
+
       $x = $this->CoGroup->find('all', array('conditions' =>
                                              array('CoGroup.name' => $reqdata['CoGroup']['name'],
                                                    'CoGroup.co_id' => $this->cur_co['Co']['id'])));
-      
+
       if(!empty($x)) {
         if($this->request->is('restful')) {
           $this->Api->restResultHeader(403, "Name In Use");
         } else {
           $this->Flash->set(_txt('er.gr.exists', array($reqdata['CoGroup']['name'])), array('key' => 'error'));
         }
-        
+
         return false;
       }
     }
-    
+
     // Do not allow edits to automatic groups. This probably isn't exactly right, as
     // ultimately it should be possible to (eg) change the description of an automatic group.
     if($curdata['CoGroup']['auto']) {
@@ -167,13 +166,13 @@ class CoGroupsController extends StandardController {
       } else {
         $this->Flash->set(_txt('er.gr.auto.edit'), array('key' => 'error'));
       }
-      
+
       return false;
     }
-    
+
     return true;
   }
-  
+
   /**
    * Perform any followups following a write operation.  Note that if this
    * method fails, it must return a warning or REST response, but that the
@@ -188,15 +187,15 @@ class CoGroupsController extends StandardController {
    * @param  Array Original request data (unmodified by callbacks)
    * @return boolean true if dependency checks succeed, false otherwise.
    */
-  
+
   function checkWriteFollowups($reqdata, $curdata = null, $origdata = null) {
     $fn = "CoGroupsController@checkWriteFollowups";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
     // Add the co person as owner/member of the new group, but only via HTTP
-    
+
     if(!$this->request->is('restful') && $this->action == 'add') {
       $cos = $this->Session->read('Auth.User.cos');
-      
+
       // Member of current CO? (Platform admin wouldn't be)
       if(isset($cos) && isset($cos[ $this->cur_co['Co']['name'] ]['co_person_id'])) {
         $a['CoGroupMember'] = array(
@@ -205,14 +204,14 @@ class CoGroupsController extends StandardController {
           'owner' => true,
           'member' => true
         );
-        
+
         if(!$this->CoGroup->CoGroupMember->save($a)) {
           $this->Flash->set(_txt('er.gr.init'), array('key' => 'information'));
           return false;
         }
       }
     }
-    
+
     return true;
   }
 
@@ -228,24 +227,24 @@ class CoGroupsController extends StandardController {
    * @since  COmanage Registry v0.1
    * @param  integer Object identifier (eg: cm_co_groups:id) representing object to be retrieved
    */
-  
+
   function edit($id) {
     $fn = "CoGroupsController@edit";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
     // Mostly, we want the standard behavior.  However, we need to retrieve the
     // set of members when rendering the edit form.
-    
+
     if(!$this->request->is('restful') && $this->request->is('get')) {
       // Retrieve the set of all group members for group with ID $id.
       // Specify containable behavior to get necessary relations.
-      
+
       $this->set('vv_co_group_members', $this->CoGroup->findSortedMembers($id));
     }
-    
+
     // Invoke the StandardController edit
     parent::edit($id);
   }
-  
+
   /**
    * Generate history records for a transaction. This method is intended to be
    * overridden by model-specific controllers, and will be called from within a
@@ -258,7 +257,7 @@ class CoGroupsController extends StandardController {
    * @param  Array Previous data (for delete/edit)
    * @return boolean Whether the function completed successfully (which does not necessarily imply history was recorded)
    */
-  
+
   public function generateHistory($action, $newdata, $olddata) {
     $fn = "CoGroupsController@generateHistory";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
@@ -292,10 +291,10 @@ class CoGroupsController extends StandardController {
                                                $this->CoGroup->id);
         break;
     }
-    
+
     return true;
   }
-  
+
   /**
    * Obtain all CO Groups.
    * - postcondition: $<object>s set on success (REST or HTML), using pagination (HTML only)
@@ -304,17 +303,17 @@ class CoGroupsController extends StandardController {
    *
    * @since  COmanage Registry v0.6
    */
-  
+
   function index() {
-    $fn = "CoGroupsController@index";
+    $fn = "index";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
     if($this->request->is('restful') && !empty($this->params['url']['copersonid'])) {
       // We need to retrieve via a join, which StandardController::index() doesn't
       // currently support.
-      
+
       try {
         $groups = $this->CoGroup->findForCoPerson($this->params['url']['copersonid']);
-        
+
         if(!empty($groups)) {
           $this->set('co_groups', $this->Api->convertRestResponse($groups));
         } else {
@@ -330,7 +329,7 @@ class CoGroupsController extends StandardController {
       parent::index();
     }
   }
-  
+
   /**
    * Authorization for this Controller, called by Auth component
    * - precondition: Session.Auth holds data used for authz decisions
@@ -339,38 +338,38 @@ class CoGroupsController extends StandardController {
    * @since  COmanage Registry v0.1
    * @return Array Permissions
    */
-  
+
   function isAuthorized() {
-    $fn = "CoGroupsController@isAuthorized";
+    $fn = "isAuthorized";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
     $roles = $this->Role->calculateCMRoles();
-    
+
     $own = array();
     $member = array();
     $managed = false;
     $managedp = false;
     $readonly = false;
     $self = false;
-    
+
     if(!empty($roles['copersonid'])) {
       $args = array();
       $args['conditions']['CoGroupMember.co_person_id'] = $roles['copersonid'];
       $args['conditions']['CoGroupMember.owner'] = true;
       $args['contain'] = false;
-      
+
       $own = $this->CoGroup->CoGroupMember->find('all', $args);
-      
+
       $args = array();
       $args['conditions']['CoGroupMember.co_person_id'] = $roles['copersonid'];
       $args['conditions']['CoGroupMember.member'] = true;
       $args['contain'] = false;
-      
+
       $member = $this->CoGroup->CoGroupMember->find('all', $args);
-      
+
       if(!empty($this->request->params['pass'][0])) {
         $managed = $this->Role->isGroupManager($roles['copersonid'], $this->request->params['pass'][0]);
       }
-      
+
       if(!empty($this->request->params['named']['copersonid'])) {
         $managedp = $this->Role->isCoAdminForCoPerson($roles['copersonid'],
                                                       $this->request->params['named']['copersonid']);
@@ -381,102 +380,104 @@ class CoGroupsController extends StandardController {
         $self = true;
       }
     }
-    
+
     if(!empty($this->request->params['pass'][0])) {
       $readonly = $this->CoGroup->readOnly(filter_var($this->request->params['pass'][0], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH | FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_BACKTICK));
     }
-    
+
     // Construct the permission set for this user, which will also be passed to the view.
     $p = array();
-    
+
     // Determine what operations this user can perform
-    
+
     // Add a new Group?
     $p['add'] = ($roles['cmadmin'] || $roles['coadmin'] || $roles['comember']);
-    
+
     // Create an admin Group?
     $p['admin'] = ($roles['cmadmin'] || $roles['coadmin']);
-    
+
     // Delete an existing Group?
     $p['delete'] = (!$readonly && ($roles['cmadmin'] || $managed));
-    
+
     // Edit an existing Group?
     $p['edit'] = (!$readonly && ($roles['cmadmin'] || $managed));
-    
+
     // View history for an existing Group?
     $p['history'] = ($roles['cmadmin'] || $roles['coadmin'] || $managed);
-    
+
     // View all existing Groups?
     $p['index'] = ($roles['cmadmin'] || $roles['coadmin'] || $roles['comember']);
-    
+
     // Reconcile memberships in a members group?
     $p['reconcile'] = ((empty($this->request->params['pass'][0]) || $readonly)
                        && ($roles['cmadmin'] || $roles['coadmin']));
-    
+
     if($this->action == 'index' && $p['index']
        && ($roles['cmadmin'] || $roles['coadmin'])) {
       // Set all permissions for admins so index view links render.
-      
+
       $p['delete'] = true;
       $p['edit'] = true;
       $p['reconcile'] = true;
       $p['view'] = true;
     }
-    
+
     if(isset($own)) {
       // Set array of groups where person is owner
-      
+
       $p['owner'] = array();
-      
+
       foreach($own as $g) {
         $p['owner'][] = $g['CoGroupMember']['co_group_id'];
       }
     }
-    
+
     if(isset($member)) {
       // Set array of groups where person is member
       $p['member'] = array();
-      
+
       foreach($member as $g) {
         $p['member'][] = $g['CoGroupMember']['co_group_id'];
       }
     }
-    
+
     // (Re)provision an existing CO Group?
     $p['provision'] = ($roles['cmadmin'] || $roles['coadmin'] || $roles['couadmin']);
-    
+
     // Select from a list of potential Groups to join?
     $p['select'] = ($roles['cmadmin']
                     || ($managedp && ($roles['coadmin'] || $roles['couadmin']))
                     || $self);
-    
+
+    // Search from a list of potential Groups to join?
+    $p['search'] = ($roles['cmadmin']
+                    || ($managedp && ($roles['coadmin'] || $roles['couadmin']))
+                    || $self);
+
     // Select from any Group (not just open or owned)?
     $p['selectany'] = ($roles['cmadmin']
                        || ($managedp && ($roles['coadmin'] || $roles['couadmin'])));
-    
+
     // View an existing Group?
     $p['view'] = ($roles['cmadmin'] || $roles['coadmin'] || $managed);
-    
-    $p['search'] = ($roles['cmadmin'] || $roles['coadmin'] || $managed);
-
     if($this->action == 'view'
        && isset($this->request->params['pass'][0])) {
       // Adjust permissions for members and open groups
-      
+
       if(isset($member) && in_array($this->request->params['pass'][0], $p['member']))
         $p['view'] = true;
-      
+
       $args = array();
       $args['conditions']['CoGroup.id'] = $this->request->params['pass'][0];
       $args['contain'] = false;
-      
+
       $g = $this->CoGroup->find('first', $args);
-      
+
       if(!empty($g) && isset($g['CoGroup']['open']) && $g['CoGroup']['open']) {
         $p['view'] = true;
       }
     }
-    
+
     $this->set('permissions', $p);
     return $p[$this->action];
   }
@@ -489,7 +490,7 @@ class CoGroupsController extends StandardController {
    * @since  COmanage Registry v1.0.4
    * @return Integer The CO ID if found, or -1 if not
    */
-  
+
   public function parseCOID($data = null) {
     $fn = "CoGroupsController@parseCOID";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
@@ -500,44 +501,44 @@ class CoGroupsController extends StandardController {
         return $coId;
       }
     }
-    
+
     return parent::parseCOID();
   }
-  
+
   /**
    * Obtain provisioning status for CO Group
    *
    * @param  integer CO Group ID
    * @since  COmanage Registry v0.8.2
    */
-  
+
   function provision($id) {
     $fn = "CoGroupsController@provision";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
     if(!$this->request->is('restful')) {
       // Pull some data for the view to be able to render
       $this->set('co_provisioning_status', $this->CoGroup->provisioningStatus($id));
-      
+
       $args = array();
       $args['conditions']['CoGroup.id'] = $id;
       $args['contain'] = false;
-      
+
       $this->set('co_group', $this->CoGroup->find('first', $args));
       $this->set('title_for_layout',
                  _txt('fd.prov.status.for',
                       array(filter_var($this->viewVars['co_group']['CoGroup']['name'],FILTER_SANITIZE_SPECIAL_CHARS))));
     }
   }
-  
+
   /**
    * Reconcile existence of automatic groups and memberships.
    * - postcondition: HTTP status returned (REST)
    * - postcondition: Redirect issued (HTML)
-   * 
+   *
    * @since COmanage Registry v0.9.3
    * @param integer CO Group ID of automatic group to reconcile, or null to reconcile existence of automatic groups
    */
-  
+
   function reconcile($id = null) {
     $fn = "CoGroupsController@reconcile";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
@@ -545,74 +546,74 @@ class CoGroupsController extends StandardController {
       // Not currently supported
       $this->performRedirect();
     }
-  
+
     // If no id then reconcile the existence of the default groups
     if(!$id) {
       $coId = $this->request->query('coid');
-      
+
       if(!isset($coId)) {
         $this->Api->restResultHeader(404, 'CO Unknown');
         return;
       }
-      
+
       $args = array();
       $args['conditions']['Co.id'] = $coId;
       $args['contain'] = false;
       $co = $this->CoGroup->Co->find('first', $args);
-      
+
       if(empty($co)) {
         $this->Api->restResultHeader(404, 'CO Unknown');
         return;
       }
-      
+
       try {
         $this->CoGroup->addDefaults($coId);
       }
       catch(Exception $e) {
         $this->Api->restResultHeader(500, $e->getMessage());
-        return;        
+        return;
       }
-      
+
       // Now find and return all automatic groups for the CO.
       $args = array();
       $args['conditions']['CoGroup.co_id'] = $coId;
       $args['conditions']['CoGroup.auto'] = true;
       $args['contain'] = false;
       $groups = $this->CoGroup->find('all', $args);
-      
+
       $this->set('co_groups', $this->Api->convertRestResponse($groups));
       $this->Api->restResultHeader(200, 'OK');
-      return; 
+      return;
     } else {
       // Find the group with the input id.
       $args = array();
       $args['conditions']['CoGroup.id'] = $id;
       $args['contain'] = false;
       $group = $this->CoGroup->find('first', $args);
-      
+
       if(empty($group)) {
         $this->Api->restResultHeader(400, 'Not a valid id');
         return;
       }
-      
+
       if(!$group['CoGroup']['auto']) {
         $this->Api->restResultHeader(400, 'Not an automatic group');
         return;
       }
-      
+
       try {
         $this->CoGroup->reconcileAutomaticGroup($id);
         $this->Api->restResultHeader(200, 'OK');
       }
       catch(Exception $e) {
         $this->Api->restResultHeader(500, $e->getMessage());
-        return; 
-      }      
-      
+        return;
+      }
+
       return;
     }
   }
-  
+
   /**
    * Obtain groups available for a CO Person to join.
    * - precondition: $this->request->params holds copersonid XXX we don't do anything with this yet
@@ -621,19 +622,19 @@ class CoGroupsController extends StandardController {
    *
    * @since  COmanage Registry v0.1
    */
-  
+
   function select() {
     $fn = "select";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
     // Lookup the person in question to find their name
-    
+
     $args = array();
     $args['conditions']['CoPerson.id'] = (!empty($this->request->params['named']['copersonid'])
                                           ? $this->request->params['named']['copersonid']
                                           // Default to the current user
                                           : $this->Session->read('Auth.User.co_person_id'));
     $args['contain'] = array('PrimaryName');
-    
+
     $coPerson = $this->CoGroup->CoGroupMember->CoPerson->find('first', $args);
 
     if(!empty($coPerson)) {
@@ -645,10 +646,10 @@ class CoGroupsController extends StandardController {
       $this->Flash->set(_txt('er.co.notmember'), array('key' => 'error'));
       $this->performRedirect();
     }
-    
+
     // XXX proper authz here is probably something like "(all open CO groups
     // and all CO groups that I own) that CO Person isn't already a member of)"
-    
+
     // XXX Don't use server side pagination
     // $params['conditions'] = array($req.'.co_id' => $this->params['named']['co']); or ['url']['coid'] for REST
     // $this->set('co_groups', $model->find('all', $params));
@@ -688,8 +689,8 @@ class CoGroupsController extends StandardController {
     $paginated_data = $this->Paginator->paginate('CoGroup');
     //$this->log(get_class($this)."::{$fn}::paginated data => ".print_r($paginated_data, true), LOG_DEBUG);
     $this->set('co_groups', $paginated_data);
-  }      
-  
+  }
+
   /**
    * Retrieve a CO Group.
    * - precondition: <id> must exist
@@ -700,14 +701,14 @@ class CoGroupsController extends StandardController {
    * @since  COmanage Registry v0.1
    * @param  integer Object identifier (eg: cm_co_groups:id) representing object to be retrieved
    */
-  
+
   function view($id) {
     $fn = "CoGroupsController@view";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
     if(!$this->request->is('restful')) {
       $this->set('vv_co_group_members', $this->CoGroup->findSortedMembers($id));
     }
-    
+
     // Invoke the StandardController view
     parent::view($id);
   }
@@ -718,13 +719,13 @@ class CoGroupsController extends StandardController {
    *
    * @since  COmanage Registry RCIAM v3.1.1
    */
-  
+
   public function search() {
     $fn = "search";
     $this->log(get_class($this)."::{$fn}::@", LOG_DEBUG);
-    $url['action'] = 'select';
+    $url['action'] = isset($this->data['Action']['name']) ? $this->data['Action']['name'] : 'index';
     $url['controller'] = 'CoGroups';
-    
+
     // build a URL will all the search elements in it
     // the resulting URL will be
     // example.com/registry/co_people/index/Search.givenName:albert/Search.familyName:einstein
@@ -734,10 +735,8 @@ class CoGroupsController extends StandardController {
         $url['Search.'.$field] = $value;
       }
     }
-    
+
     $url['co'] = $this->cur_co['Co']['id'];
-    //$this->log(get_class($this)."::{$fn}::url => " . print_r($url,true), LOG_DEBUG);
-    // redirect the user to the url
     $this->redirect($url, null, true);
   }
 
@@ -767,46 +766,56 @@ class CoGroupsController extends StandardController {
   /**
    * Determine the conditions for pagination of the index view, when rendered via the UI.
    *
+   * @since  COmanage Registry v3.1.1
+   * @return Array An array suitable for use in $this->paginate
+   */
+
+  /**
+   * Determine the conditions for pagination of the index view, when rendered via the UI.
+   *
    * @since  COmanage Registry v0.8
    * @return Array An array suitable for use in $this->paginate
    */
-  
+
   public function paginationConditions() {
-    $fn = "CoGroupsController@paginationConditions";
+    $fn = "paginationConditions";
     $this->log(get_class($this)."::{$fn}::@ ", LOG_DEBUG);
     $pagcond = array();
-    
+
     // Set page title
     $this->set('title_for_layout', _txt('fd.co_people.search'));
     // Use server side pagination
-    
+
     if($this->requires_co) {
       $pagcond['conditions']['CoGroup.co_id'] = $this->cur_co['Co']['id'];
     }
-    
-    // Filtering by name operates using any name, so preferred or other names
-    // can also be searched. However, filter by letter ("familyNameStart") only
-    // works on PrimaryName so that the results match the index list.
-    
+
     // Filter by name
     if(!empty($this->params['named']['Search.name'])) {
       $searchterm = strtolower($this->params['named']['Search.name']);
       // We set up LOWER() indices on these columns (CO-1006)
-      $pagcond['conditions']['LOWER(Name.given) LIKE'] = "%$searchterm%";
+      $pagcond['conditions']['LOWER(CoGroup.name) LIKE'] = "%$searchterm%";
     }
-    
+
     // Filter by description
     if(!empty($this->params['named']['Search.desc'])) {
       $searchterm = strtolower($this->params['named']['Search.desc']);
-      $pagcond['conditions']['LOWER(Name.family) LIKE'] = "%$searchterm%";
+      $pagcond['conditions']['LOWER(CoGroup.description) LIKE'] = "%$searchterm%";
     }
-    
-    // Filter by category (ONLY for LOFAR)
-    if(!empty($this->params['named']['Search.category'])) {
-      $searchterm = strtolower($this->params['named']['Search.category']);
-      $pagcond['conditions']['LOWER(PrimaryName.family) LIKE'] = "$searchterm%";
+
+    // LOFAR Community filtering support
+    if(isset($this->request->params['named']['Search.category']) && count($this->request->params['named']['Search.category'])>0){
+      $categories = array_map(function($val){return "%{$val}%";}, $this->request->params['named']['Search.category']);
+      $pagcond['conditions']['OR'] = array();
+      foreach($categories as $key=>$category){
+        //$this->log(get_class($this)."::{$fn}::category => ".$category, LOG_DEBUG);
+        $tmp = array();
+        $tmp['CoGroup.name LIKE'] = $category;
+        $pagcond['conditions']['OR'][$key] = $tmp;
+        unset($tmp);
+      }
     }
-    
+
     return $pagcond;
   }
 }

--- a/app/View/CoGroups/index.ctp
+++ b/app/View/CoGroups/index.ctp
@@ -18,7 +18,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * @link          http://www.internet2.edu/comanage COmanage Project
  * @package       registry
  * @since         COmanage Registry v0.1
@@ -111,13 +111,13 @@
 
 <script type="text/javascript">
   // This is based in large part on CoProvisioningTargets/index.ctp
-  
+
   // IDs of the members groups to be reconciled individually
   var ids = [ ];
-  
+
   // Have we been interrupted by the user?
   var canceled = 0;
-  
+
   function js_confirm_reconcile(targetUrl) {
     // Prep confirmation dialog
     $("#reconcile-dialog").dialog("option",
@@ -128,29 +128,29 @@
                                          js_request_reconcile(targetUrl);
                                        } }
                                      ] );
-    
+
     // Open the dialog to confirm autogenerate
     $("#reconcile-dialog").dialog("open");
   }
-  
+
   function js_execute_reconcile(index, baseUrl) {
     if(!canceled && index < ids.length) {
       var id = ids[index];
-      
+
       // Update the progress bar
       $("#reconcile-progressbar").progressbar("option", "value", index);
-      
+
       // Initiate the reconcile request
       var jqxhr = $.ajax({
         url: baseUrl + "/" + id + ".json",
         type: 'PUT'
         });
-      
+
       // On success, fire the next request
       jqxhr.done(function(data, textStatus, jqXHR) {
                   js_execute_reconcile(index+1, baseUrl);
                 });
-      
+
       jqxhr.fail(function(jqXHR, textStatus, errorThrown) {
                   if(jqXHR.status != "200") {
                     $("#progressbar-dialog").dialog("close");
@@ -185,17 +185,17 @@
         $("#result-dialog").html("<p><?php print _txt('rs.gr.reconcile.ok'); ?></p>");
         $("#result-dialog").dialog("open");
       }
-      
+
       // Reset in case user tries again
       canceled = 0;
       $("#reconcile-progressbar").progressbar("option", "value", 0);
     }
   }
-  
+
   function js_request_reconcile(targetUrl) {
     // Open the progress bar dialog
     $("#progressbar-dialog").dialog("open");
-    
+
     // Reconcile existence of members groups
     var jqxhr = $.ajax({
       url: targetUrl,
@@ -210,7 +210,7 @@
             }
           // Reset max on progress bar now that ids is updated
           $("#reconcile-progressbar").progressbar("option", "max", ids.length);
-          
+
           // Fire off the first group reconcile
           var baseUrl = targetUrl.split('?')[0];
           baseUrl = baseUrl.slice(0,-5);
@@ -228,14 +228,14 @@
                   $("#result-dialog").dialog("open");
                 });
   }
-  
+
   $(function() {
     // Define progressbar, note that ids.length is 0 initially
     $("#reconcile-progressbar").progressbar({
       value: 0,
       max: ids.length
     });
-    
+
     // Progress bar dialog
     $("#progressbar-dialog").dialog({
       create: function() {
@@ -257,7 +257,7 @@
         effect: "fade"
       }
     });
-    
+
     // Autogenerate dialog
     $("#reconcile-dialog").dialog({
       autoOpen: false,
@@ -278,7 +278,7 @@
         effect: "fade"
       }
     });
-    
+
     // Result dialog
     $("#result-dialog").dialog({
       autoOpen: false,
@@ -301,8 +301,8 @@
 <!-- Added this dummy div in order to force a consistent layout. Do not remove -->
 <div class="table-container"></div>
 
-<?php // Load the top search bar with its own form
-  //if(isset($permissions['search']) && $permissions['search'] ) {
+<?php //// Load the top search bar with its own form
+if(isset($permissions['search']) && $permissions['search'] && ($this->action == 'select' || $this->action='index')) {
   if(!empty($this->plugin)) {
     $fileLocation = APP . "Plugin/" . $this->plugin . "/View/CoGroups/search.inc";
     if(file_exists($fileLocation))
@@ -312,7 +312,7 @@
     if(file_exists($fileLocation))
       include($fileLocation);
   }
-  //}
+}
 ?>
 
 <?php // Load the form that will handle the save events

--- a/app/View/CoGroups/search.inc
+++ b/app/View/CoGroups/search.inc
@@ -18,7 +18,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * @link          http://www.internet2.edu/comanage COmanage Project
  * @package       registry
  * @since         COmanage Registry v0.8.3
@@ -66,10 +66,19 @@ global $cm_lang, $cm_texts;
 
 <div id="coGroupsSearch" class="top-search">
   <?php
-    print $this->Form->create('CoGroup',
-                              array('url' => array('action'=>'search'),
-                                    'id'  => 'form_search'));
-    print $this->Form->hidden('CoGroup.co_id', array('default' => $cur_co['Co']['id'])). "\n";
+  print $this->Form->create('CoGroup',
+                            array('url' => array('action'=>'search'),
+                                  'id'  => 'form_search'));
+  print $this->Form->hidden('CoGroup.co_id', array('default' => $cur_co['Co']['id'])). "\n";
+
+  $args = array();
+  $args['label'] = _txt('fd.action');
+  $args['placeholder'] = _txt('fd.action');
+  //$args['class'] = 'mdl-textfield__input';
+  $args['aria-label'] = _txt('fd.action');
+  // XXX shouldn't these fields be sanitized?
+  $args['value'] = $this->action;
+  print $this->Form->hidden('Action.name', $args);
   ?>
   <fieldset>
     <legend>
@@ -82,54 +91,54 @@ global $cm_lang, $cm_texts;
 
     <div id="top-search-fields">
       <div class="search-field-subgroup">
-      <?php
-      $args = array();
-      $args['label'] = _txt('fd.name');
-      $args['placeholder'] = _txt('fd.name');
-      //$args['class'] = 'mdl-textfield__input';
-      $args['aria-label'] = _txt('fd.name');
-      // XXX shouldn't these fields be sanitized?
-      $args['value'] = !empty($this->request->params['named']['Search.name']) ? $this->request->params['named']['Search.name'] : '';
-      print $this->Form->input('Search.name',$args);
-      ?>
+        <?php
+        $args = array();
+        $args['label'] = _txt('fd.name');
+        $args['placeholder'] = _txt('fd.name');
+        //$args['class'] = 'mdl-textfield__input';
+        $args['aria-label'] = _txt('fd.name');
+        // XXX shouldn't these fields be sanitized?
+        $args['value'] = !empty($this->request->params['named']['Search.name']) ? $this->request->params['named']['Search.name'] : '';
+        print $this->Form->input('Search.name',$args);
+        ?>
       </div>
 
       <div class="search-field-subgroup">
-      <?php
-      $args = array();
-      $args['label'] = _txt('fd.desc');
-      $args['placeholder'] = _txt('fd.desc');
-      //$args['class'] = 'mdl-textfield__input';
-      $args['aria-label'] = _txt('fd.desc');
-      // XXX shouldn't these fields be sanitized?
-      $args['value'] = !empty($this->request->params['named']['Search.desc']) ? $this->request->params['named']['Search.desc'] : '';
-      print $this->Form->input('Search.desc',$args);
-      ?>
+        <?php
+        $args = array();
+        $args['label'] = _txt('fd.desc');
+        $args['placeholder'] = _txt('fd.desc');
+        //$args['class'] = 'mdl-textfield__input';
+        $args['aria-label'] = _txt('fd.desc');
+        // XXX shouldn't these fields be sanitized?
+        $args['value'] = !empty($this->request->params['named']['Search.desc']) ? $this->request->params['named']['Search.desc'] : '';
+        print $this->Form->input('Search.desc',$args);
+        ?>
       </div>
 
       <?php if ($astron_co >= 1) { ?>
-            <div id="groupTypes">
-              <legend>Proposal Category</legend>
-              <?php
-                // Build array of options based on model validation
-                $searchOptions = $cm_texts[ $cm_lang ]['en.lofar.group.category'];
+        <div id="groupTypes">
+          <legend>Proposal Category</legend>
+          <?php
+          // Build array of options based on model validation
+          $searchOptions = $cm_texts[ $cm_lang ]['en.lofar.group.category'];
 
-                // Build array to check off actively used filters on the page
-                $selected = array();
+          // Build array to check off actively used filters on the page
+          $selected = array();
 
-                if(isset($this->passedArgs['Search.category'])) {
-                  $selected = $this->passedArgs['Search.category'];
-                }
+          if(isset($this->passedArgs['Search.category'])) {
+            $selected = $this->passedArgs['Search.category'];
+          }
 
-                // Collect parameters and print checkboxes
-                $formParams = array('options'  => $searchOptions,
-                  'multiple' => 'checkbox',
-                  'label'    => false,
-                  'selected' => $selected);
+          // Collect parameters and print checkboxes
+          $formParams = array('options'  => $searchOptions,
+            'multiple' => 'checkbox',
+            'label'    => false,
+            'selected' => $selected);
 
-                print $this->Form->input('Search.category', $formParams);
-              ?>
-            </div>
+          print $this->Form->input('Search.category', $formParams);
+          ?>
+        </div>
       <?php } ?>
 
       <div class="topSearchSubmit">


### PR DESCRIPTION
This pull request 
Fixes:
- Permissions for CO Groups Search
 - After the fix the search can be executed by a cmadmin, coadmin, couadmin, department manager, self
- Semi implementation of Search related to CoGroups/Index page
 - Made possible to distinguish if the search request comes from index or select page
 - Added support for Lofar for Index page Search. Before was only implemented for Select page
 - paginationConditions function corrected to match the CoGroup Model