### PR TITLE
[RCIAM-83] Added support for CoGroup Search both for Index(All Groups) and Selec…

### DIFF
--- a/app/View/CoGroups/index.ctp
+++ b/app/View/CoGroups/index.ctp
@@ -302,17 +302,17 @@
 <div class="table-container"></div>
 
 <?php // Load the top search bar with its own form
-  //if(isset($permissions['search']) && $permissions['search'] ) {
-  if(!empty($this->plugin)) {
-    $fileLocation = APP . "Plugin/" . $this->plugin . "/View/CoGroups/search.inc";
-    if(file_exists($fileLocation))
-      include($fileLocation);
-  } else {
-    $fileLocation = APP . "View/CoGroups/search.inc";
-    if(file_exists($fileLocation))
-      include($fileLocation);
+  if(isset($permissions['search']) && $permissions['search'] && ($this->action == 'select' || $this->action='index')) {
+    if(!empty($this->plugin)) {
+      $fileLocation = APP . "Plugin/" . $this->plugin . "/View/CoGroups/search.inc";
+      if(file_exists($fileLocation))
+        include($fileLocation);
+    } else {
+      $fileLocation = APP . "View/CoGroups/search.inc";
+      if(file_exists($fileLocation))
+        include($fileLocation);
+    }
   }
-  //}
 ?>
 
 <?php // Load the form that will handle the save events

--- a/app/View/CoGroups/search.inc
+++ b/app/View/CoGroups/search.inc
@@ -70,6 +70,15 @@ global $cm_lang, $cm_texts;
                               array('url' => array('action'=>'search'),
                                     'id'  => 'form_search'));
     print $this->Form->hidden('CoGroup.co_id', array('default' => $cur_co['Co']['id'])). "\n";
+
+    $args = array();
+    $args['label'] = _txt('fd.action');
+    $args['placeholder'] = _txt('fd.action');
+    //$args['class'] = 'mdl-textfield__input';
+    $args['aria-label'] = _txt('fd.action');
+    // XXX shouldn't these fields be sanitized?
+    $args['value'] = $this->action;
+    print $this->Form->hidden('Action.name', $args);
   ?>
   <fieldset>
     <legend>


### PR DESCRIPTION

- Fixed permissions for CO Groups Search
  - After the fix the search can be executed by a cmadmin, coadmin, couadmin, department manager, self
- Search related to CoGroups Model
  - Made possible to distinguish if the search request comes from index(All Groups) or select(My Groups) page and correctly redirect
  - Added Search support for LOFAR community for Index(All Groups) page. Before, only Select(My Groups) page was implemented 
  - paginationConditions function in CoGroupsController.php corrected to match the CoGroup Model
- Removed unnecessary debug logs