### PR TITLE
[RCIAM-82] Add hidden option for c omanage registry enrollment flows

### DIFF
--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -1332,6 +1332,7 @@
     <field name="redirect_on_finalize" type="C" size="1024" />
     <field name="return_url_whitelist" type="X" size="4000" />
     <field name="ignore_authoritative" type="L" />
+    <field name="hide" type="L" />
     <field name="duplicate_mode" type="C" size="2" />
     <field name="co_theme_id" type="I">
       <constraint>REFERENCES cm_co_themes(id)</constraint>

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1081,6 +1081,8 @@ original notification at
   'fd.ea.ignauth' =>  'Ignore Authoritative Values',
   'fd.ea.ignauth.flow.desc' => 'Ignore authoritative values for attributes attached to this flow, such as those provided via environment variables, SAML, or LDAP (CMP Enrollment Attributes only, setting does not apply to Enrollment Sources)',
   'fd.ea.ignauth.desc' => 'Ignore authoritative values for this attribute, such as those provided via environment variables, SAML, or LDAP',
+  'fd.ea.hide' =>  'Hide Enrollment Flow',
+  'fd.ea.hide.desc' =>  'Choose whether the Enrollment Flow will be visible to users',
   'fd.ea.default_env' => 'Environment Variable For Default Value',
   'fd.ea.default_env.desc' => 'If populated, the value of this environment variable will be used as the default value for this attribute (See also <a href="https://spaces.internet2.edu/x/mA39Bg#ConsumingExternalAttributesviaWebServerEnvironmentVariables-PopulatingDefaultValuesDuringEnrollment">this documentation</a>)',
   'fd.ea.desc'    =>  'Description',

--- a/app/Model/CoEnrollmentFlow.php
+++ b/app/Model/CoEnrollmentFlow.php
@@ -261,6 +261,11 @@ class CoEnrollmentFlow extends AppModel {
       'required' => false,
       'allowEmpty' => true
     ),
+    'hide' => array(
+      'rule' => array('boolean'),
+      'required' => false,
+      'allowEmpty' => true
+    ),
     'duplicate_mode' => array(
       'rule' => array('inList',
                       array(EnrollmentDupeModeEnum::Duplicate,

--- a/app/View/CoEnrollmentFlows/fields.inc
+++ b/app/View/CoEnrollmentFlows/fields.inc
@@ -834,6 +834,23 @@
                    : filter_var($co_enrollment_flows[0]['CoEnrollmentFlow']['return_url_whitelist'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
     </div>
   </li>
+    <li>
+    <div class="field-name">
+      <div class="field-title">
+        <?php print ($e ? $this->Form->label('hide', _txt('fd.ea.hide')) : _txt('fd.ea.hide')); ?>
+      </div>
+      <div class="field-desc"><?php print _txt('fd.ea.hide.desc'); ?></div>
+    </div>
+    <div class="field-info">
+      <?php
+        print ($e
+               ? $this->Form->input('hide',
+                                    array('default' => false))
+               : ($co_enrollment_flows[0]['CoEnrollmentFlow']['hide']
+                  ? _txt('fd.yes') : _txt('fd.no')));
+      ?>
+    </div>
+  </li>
   <?php if(isset($vv_attributes_from_env) && $vv_attributes_from_env): ?>
   <li>
     <div class="field-name">

--- a/app/View/CoEnrollmentFlows/select.ctp
+++ b/app/View/CoEnrollmentFlows/select.ctp
@@ -59,64 +59,64 @@
 
   <?php $i = 0; ?>
   <?php foreach ($co_enrollment_flows as $c): ?>
-    <div class="mdl-grid">
-      <div class="mdl-cell mdl-cell--9-col mdl-cell--6-col-tablet mdl-cell--2-col-phone first-cell">
-        <?php print filter_var($c['CoEnrollmentFlow']['name'],FILTER_SANITIZE_SPECIAL_CHARS); ?>
-      </div>
-      <div class="mdl-cell mdl-cell--2-col actions">
-        <?php
-          if($permissions['select']) {
-            
-            // begin button
-            print $this->Html->link(_txt('op.begin') . ' <em class="material-icons" aria-hidden="true">forward</em>',
-              array(
-                'controller' => 'co_petitions',
-                'action' => 'start',
-                'coef' => $c['CoEnrollmentFlow']['id']
-              ),
-              array(
-                'class' => 'co-button mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect',
-                'escape' => false
-              )
-            ) . "\n";
-
-            // QR code button - requires GD2 library
-            if (extension_loaded ("gd")) {
-              print $this->Html->link(
-                $this->Html->image(
-                  'qrcode-icon.png',
-                  array(
-                    'alt' => _txt('op.display.qr.for',array(filter_var($c['CoEnrollmentFlow']['name'],FILTER_SANITIZE_SPECIAL_CHARS)))
-                  )
+    <?php if(!$c['CoEnrollmentFlow']['hide']): ?>
+      <div class="mdl-grid">
+        <div class="mdl-cell mdl-cell--9-col mdl-cell--6-col-tablet mdl-cell--2-col-phone first-cell">
+          <?php print filter_var($c['CoEnrollmentFlow']['name'],FILTER_SANITIZE_SPECIAL_CHARS); ?>
+        </div>
+        <div class="mdl-cell mdl-cell--2-col actions">
+          <?php
+            if($permissions['select']) {
+              // begin button
+              print $this->Html->link(_txt('op.begin') . ' <em class="material-icons" aria-hidden="true">forward</em>',
+                array(
+                  'controller' => 'co_petitions',
+                  'action' => 'start',
+                  'coef' => $c['CoEnrollmentFlow']['id']
                 ),
                 array(
-                  'controller' => 'qrcode',
-                  '?' => array(
-                    'c' => $this->Html->url(
-                      array(
-                        'controller' => 'co_petitions',
-                        'action' => 'start',
-                        'coef' => $c['CoEnrollmentFlow']['id']
-                      ),
-                      array(
-                        'full' => true,
-                        'escape' => false
-                      )
-                    )
-                  )
-                ),
-                array(
-                  'class' => 'co-button qr-button mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect', 
-                  'escape' => false,
-                  'title'  => _txt('op.display.qr.for',array($c['CoEnrollmentFlow']['name']))
+                  'class' => 'co-button mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect',
+                  'escape' => false
                 )
               ) . "\n";
+              // QR code button - requires GD2 library
+              if (extension_loaded ("gd")) {
+                print $this->Html->link(
+                  $this->Html->image(
+                    'qrcode-icon.png',
+                    array(
+                      'alt' => _txt('op.display.qr.for',array(filter_var($c['CoEnrollmentFlow']['name'],FILTER_SANITIZE_SPECIAL_CHARS)))
+                    )
+                  ),
+                  array(
+                    'controller' => 'qrcode',
+                    '?' => array(
+                      'c' => $this->Html->url(
+                        array(
+                          'controller' => 'co_petitions',
+                          'action' => 'start',
+                          'coef' => $c['CoEnrollmentFlow']['id']
+                        ),
+                        array(
+                          'full' => true,
+                          'escape' => false
+                        )
+                      )
+                    )
+                  ),
+                  array(
+                    'class' => 'co-button qr-button mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect', 
+                    'escape' => false,
+                    'title'  => _txt('op.display.qr.for',array($c['CoEnrollmentFlow']['name']))
+                  )
+                ) . "\n";
+              }
             }
-          }
-        ?>
+          ?>
+        </div>
       </div>
-    </div>
-    <?php $i++; ?>
+      <?php $i++; ?>
+    <?php endif; ?>
   <?php endforeach; ?>
   <div class="clearfix"></div>
 </div>

--- a/app/View/CoGroups/index.ctp
+++ b/app/View/CoGroups/index.ctp
@@ -302,17 +302,17 @@
 <div class="table-container"></div>
 
 <?php // Load the top search bar with its own form
-  //if(isset($permissions['search']) && $permissions['search'] ) {
-  if(!empty($this->plugin)) {
-    $fileLocation = APP . "Plugin/" . $this->plugin . "/View/CoGroups/search.inc";
-    if(file_exists($fileLocation))
-      include($fileLocation);
-  } else {
-    $fileLocation = APP . "View/CoGroups/search.inc";
-    if(file_exists($fileLocation))
-      include($fileLocation);
+  if(isset($permissions['search']) && $permissions['search'] && ($this->action == 'select' || $this->action='index')) {
+    if(!empty($this->plugin)) {
+      $fileLocation = APP . "Plugin/" . $this->plugin . "/View/CoGroups/search.inc";
+      if(file_exists($fileLocation))
+        include($fileLocation);
+    } else {
+      $fileLocation = APP . "View/CoGroups/search.inc";
+      if(file_exists($fileLocation))
+        include($fileLocation);
+    }
   }
-  //}
 ?>
 
 <?php // Load the form that will handle the save events

--- a/app/View/CoGroups/search.inc
+++ b/app/View/CoGroups/search.inc
@@ -70,6 +70,15 @@ global $cm_lang, $cm_texts;
                               array('url' => array('action'=>'search'),
                                     'id'  => 'form_search'));
     print $this->Form->hidden('CoGroup.co_id', array('default' => $cur_co['Co']['id'])). "\n";
+
+    $args = array();
+    $args['label'] = _txt('fd.action');
+    $args['placeholder'] = _txt('fd.action');
+    //$args['class'] = 'mdl-textfield__input';
+    $args['aria-label'] = _txt('fd.action');
+    // XXX shouldn't these fields be sanitized?
+    $args['value'] = $this->action;
+    print $this->Form->hidden('Action.name', $args);
   ?>
   <fieldset>
     <legend>


### PR DESCRIPTION
# Feature
Added the configuration variable **hide** in **Co Enrolment Flows** configuration page. By default the value is false/empty and all the configured Enrolment Flows will be displayed in `People->Enrol` page. If the Admin changes the value to true, then the Flow will be hidden.
This is very handy for **Sign Up** Flows or other flows that we want to hide from the users; since they have no meaning for them and yet they cause frustration.

The Admin will still be able to manage the flow via the configuration tab.
