### PR TITLE
[RCIAM-82] Added config option that enables a CO Enrollment Flow to be hidden fr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - by Name
   - by Description
 - Add search functionality to enrollments flow page. Enrollments can be filtered/sorted by Name
-
+- Add `hidden` functionality to Enroll page. The Admin can enable the functionality by changing the value of `Hide Enrollment Flow` field to true, in the config page of an Enrollment flow. By default the value is false/empty and all the configured Enrolment Flows will be displayed in `People->Enroll` page.
 ### Changed
 - Update email and subject DN when the user logs into registry
 - Use new [EGI theme](https://github.com/EGI-Foundation/comanage-registry-themeegi)

--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -1332,6 +1332,7 @@
     <field name="redirect_on_finalize" type="C" size="1024" />
     <field name="return_url_whitelist" type="X" size="4000" />
     <field name="ignore_authoritative" type="L" />
+    <field name="hidden" type="L" />
     <field name="duplicate_mode" type="C" size="2" />
     <field name="co_theme_id" type="I">
       <constraint>REFERENCES cm_co_themes(id)</constraint>

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1078,6 +1078,8 @@ original notification at
   'fd.domain' =>      'Domain',
   // Enrollment configuration fields
   'fd.ea.attr.copy2cop' => 'Copy this attribute to the CO Person record',
+  'fd.ea.hidden' =>  'Hide Enrollment Flow',
+  'fd.ea.hidden.desc' =>  'Choose whether the Enrollment Flow will be visible to users',
   'fd.ea.ignauth' =>  'Ignore Authoritative Values',
   'fd.ea.ignauth.flow.desc' => 'Ignore authoritative values for attributes attached to this flow, such as those provided via environment variables, SAML, or LDAP (CMP Enrollment Attributes only, setting does not apply to Enrollment Sources)',
   'fd.ea.ignauth.desc' => 'Ignore authoritative values for this attribute, such as those provided via environment variables, SAML, or LDAP',

--- a/app/Model/CoEnrollmentFlow.php
+++ b/app/Model/CoEnrollmentFlow.php
@@ -261,6 +261,11 @@ class CoEnrollmentFlow extends AppModel {
       'required' => false,
       'allowEmpty' => true
     ),
+    'hidden' => array(
+      'rule' => array('boolean'),
+      'required' => false,
+      'allowEmpty' => true
+    ),
     'duplicate_mode' => array(
       'rule' => array('inList',
                       array(EnrollmentDupeModeEnum::Duplicate,

--- a/app/View/CoEnrollmentFlows/fields.inc
+++ b/app/View/CoEnrollmentFlows/fields.inc
@@ -834,6 +834,23 @@
                    : filter_var($co_enrollment_flows[0]['CoEnrollmentFlow']['return_url_whitelist'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
     </div>
   </li>
+  <li>
+    <div class="field-name">
+      <div class="field-title">
+        <?php print ($e ? $this->Form->label('hidden', _txt('fd.ea.hidden')) : _txt('fd.ea.hidden')); ?>
+      </div>
+      <div class="field-desc"><?php print _txt('fd.ea.hidden.desc'); ?></div>
+    </div>
+    <div class="field-info">
+      <?php
+        print ($e
+               ? $this->Form->input('hidden',
+                                    array('default' => false))
+               : ($co_enrollment_flows[0]['CoEnrollmentFlow']['hidden']
+                  ? _txt('fd.yes') : _txt('fd.no')));
+      ?>
+    </div>
+  </li>
   <?php if(isset($vv_attributes_from_env) && $vv_attributes_from_env): ?>
   <li>
     <div class="field-name">

--- a/app/View/CoEnrollmentFlows/select.ctp
+++ b/app/View/CoEnrollmentFlows/select.ctp
@@ -59,64 +59,64 @@
 
   <?php $i = 0; ?>
   <?php foreach ($co_enrollment_flows as $c): ?>
-    <div class="mdl-grid">
-      <div class="mdl-cell mdl-cell--9-col mdl-cell--6-col-tablet mdl-cell--2-col-phone first-cell">
-        <?php print filter_var($c['CoEnrollmentFlow']['name'],FILTER_SANITIZE_SPECIAL_CHARS); ?>
-      </div>
-      <div class="mdl-cell mdl-cell--2-col actions">
-        <?php
-          if($permissions['select']) {
-            
-            // begin button
-            print $this->Html->link(_txt('op.begin') . ' <em class="material-icons" aria-hidden="true">forward</em>',
-              array(
-                'controller' => 'co_petitions',
-                'action' => 'start',
-                'coef' => $c['CoEnrollmentFlow']['id']
-              ),
-              array(
-                'class' => 'co-button mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect',
-                'escape' => false
-              )
-            ) . "\n";
-
-            // QR code button - requires GD2 library
-            if (extension_loaded ("gd")) {
-              print $this->Html->link(
-                $this->Html->image(
-                  'qrcode-icon.png',
-                  array(
-                    'alt' => _txt('op.display.qr.for',array(filter_var($c['CoEnrollmentFlow']['name'],FILTER_SANITIZE_SPECIAL_CHARS)))
-                  )
+    <?php if(!$c['CoEnrollmentFlow']['hidden']): ?>
+      <div class="mdl-grid">
+        <div class="mdl-cell mdl-cell--9-col mdl-cell--6-col-tablet mdl-cell--2-col-phone first-cell">
+          <?php print filter_var($c['CoEnrollmentFlow']['name'],FILTER_SANITIZE_SPECIAL_CHARS); ?>
+        </div>
+        <div class="mdl-cell mdl-cell--2-col actions">
+          <?php
+            if($permissions['select']) {
+              // begin button
+              print $this->Html->link(_txt('op.begin') . ' <em class="material-icons" aria-hidden="true">forward</em>',
+                array(
+                  'controller' => 'co_petitions',
+                  'action' => 'start',
+                  'coef' => $c['CoEnrollmentFlow']['id']
                 ),
                 array(
-                  'controller' => 'qrcode',
-                  '?' => array(
-                    'c' => $this->Html->url(
-                      array(
-                        'controller' => 'co_petitions',
-                        'action' => 'start',
-                        'coef' => $c['CoEnrollmentFlow']['id']
-                      ),
-                      array(
-                        'full' => true,
-                        'escape' => false
-                      )
-                    )
-                  )
-                ),
-                array(
-                  'class' => 'co-button qr-button mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect', 
-                  'escape' => false,
-                  'title'  => _txt('op.display.qr.for',array($c['CoEnrollmentFlow']['name']))
+                  'class' => 'co-button mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect',
+                  'escape' => false
                 )
               ) . "\n";
+              // QR code button - requires GD2 library
+              if (extension_loaded ("gd")) {
+                print $this->Html->link(
+                  $this->Html->image(
+                    'qrcode-icon.png',
+                    array(
+                      'alt' => _txt('op.display.qr.for',array(filter_var($c['CoEnrollmentFlow']['name'],FILTER_SANITIZE_SPECIAL_CHARS)))
+                    )
+                  ),
+                  array(
+                    'controller' => 'qrcode',
+                    '?' => array(
+                      'c' => $this->Html->url(
+                        array(
+                          'controller' => 'co_petitions',
+                          'action' => 'start',
+                          'coef' => $c['CoEnrollmentFlow']['id']
+                        ),
+                        array(
+                          'full' => true,
+                          'escape' => false
+                        )
+                      )
+                    )
+                  ),
+                  array(
+                    'class' => 'co-button qr-button mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect', 
+                    'escape' => false,
+                    'title'  => _txt('op.display.qr.for',array($c['CoEnrollmentFlow']['name']))
+                  )
+                ) . "\n";
+              }
             }
-          }
-        ?>
+          ?>
+        </div>
       </div>
-    </div>
-    <?php $i++; ?>
+      <?php $i++; ?>
+    <?php endif; ?>
   <?php endforeach; ?>
   <div class="clearfix"></div>
 </div>


### PR DESCRIPTION
# Feature
Added the configuration variable **hidden** in **Co Enrolment Flows** configuration page. By default the value is false/empty and all the configured Enrolment Flows will be displayed in `People->Enrol` page. If the Admin changes the value to true, then the Flow will be hidden.
This is very handy for **Sign Up** Flows or other flows that we want to hide from the users; since they have no meaning for them and yet they cause frustration.

The Admin will still be able to manage the flow via the configuration tab.

For this feature to work we need to add a column in table `cm_co_enrollment_flows`
SQL command:
```
alter table cm_co_enrollment_flows add column hidden boolean;
```