### PR TITLE
[RCIAM-86] Enable email verification for CO Person if the email has already been…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Handle multiple attribute values for email and subject DN on registration
 - Pagination functionality added in order to handle any error(s) occurred while managing large group memberships
 - Update default CO Person Role entries without linking to a COU if not applicable
+- CO Person's email gets verified during the registration process

--- a/app/Model/CoInvite.php
+++ b/app/Model/CoInvite.php
@@ -170,6 +170,16 @@ class CoInvite extends AppModel {
           if($orgId) {
             try {
               $this->CoPerson->EmailAddress->verify($orgId, null, $invite['CoInvite']['mail'], $invite['CoPetition']['enrollee_co_person_id']);
+
+              $args = array();
+              $args['conditions']['EmailAddress.co_person_id'] = $invite['CoInvite']['co_person_id'];
+              $args['conditions']['EmailAddress.mail'] = $invite['CoInvite']['mail'];
+              $args['conditions']['EmailAddress.deleted'] = false;
+              $args['contain'] = false;
+              $cp_email = $this->CoPerson->EmailAddress->find('first', $args);
+              if(isset($cp_email['EmailAddress']['id'])){
+                $this->CoPerson->EmailAddress->verify(null, $invite['CoInvite']['co_person_id'], $invite['CoInvite']['mail'], $invite['CoPetition']['enrollee_co_person_id']);
+              }
             }
             catch(Exception $e) {
               $dbc->rollback();


### PR DESCRIPTION
By default the copied Email Attribute is set as unverified and the user should trigger an action after the initial login to complete the verification. After applying the code changes, we will be able to mark the CO Person's linked email as verified, as soon as the CO Person verifies the email used from the OIS for the registration. 

_COManage 3.2.2 includes this functionality out of the box_