### PR TITLE
[RCIAM-88] Enable Localization Variables from Comanage CO to have global scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Pagination functionality added in order to handle any error(s) occurred while managing large group memberships
 - Update default CO Person Role entries without linking to a COU if not applicable
 - CO Person's email gets verified during the registration process
+- Add global scope for `Localization` variables of the default CO, COManage. This CO is only accessible by the platform administors.

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -217,6 +217,29 @@ class AppController extends Controller {
         $this->set('vv_tz', date_default_timezone_get());
       }
 
+      // Apply platform localization variables. These are the ones in COManage CO
+      // Load dynamic texts. We do this here because lang.php doesn't have access to models yet.
+      global $cm_texts;
+      global $cm_lang;
+
+      $args = array();
+      $args['joins'][0]['table'] = 'cos';
+      $args['joins'][0]['alias'] = 'Co';
+      $args['joins'][0]['type'] = 'INNER';
+      $args['joins'][0]['conditions'][0] = 'CoLocalization.co_id=Co.id';
+      $args['conditions']['Co.name'] = 'COmanage';
+      $args['conditions']['Co.status'] = StatusEnum::Active;
+      $args['conditions']['CoLocalization.language'] = $cm_lang;
+      $args['fields'] = array('CoLocalization.lkey', 'CoLocalization.text');
+      $args['contain'] = false;
+
+      $this->loadModel('CoLocalization');
+      $ls = $this->CoLocalization->find('list', $args);
+
+      if(!empty($ls)) {
+        $cm_texts[$cm_lang] = array_merge($cm_texts[$cm_lang], $ls);
+      }
+
       // Before we do anything else, check to see if a CO was provided.
       // (It might impact our authz decisions.) Note that some models (eg: MVPAs)
       // might specify a CO, but might not. As of v0.6, we no longer redirect to


### PR DESCRIPTION
Currently COManage does not support global localization variables. If i set a local variable in COmanage CO, the default CO, then it will not apply everywhere. This fix will enable this functionality. As a result, whenever the user creates a new local variable under COManage CO, this will apply everywhere. The same local variable will be overwritten by the CO specific one, if it exists. In order to create a global local variable the user needs to be a platform admin and have access to COManage CO.

lang.php => overwritten by COManage global ones => overwritten by CO local ones