### PR TITLE
[RCIAM-92] Add config variable for cookie and session name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - by Description
 - Add search functionality to enrollments flow page. Enrollments can be filtered/sorted by Name
 - Add `hidden` functionality to Enroll page. The Admin can enable the functionality by changing the value of `Hide Enrollment Flow` field to true, in the config page of an Enrollment flow. By default the value is false/empty and all the configured Enrolment Flows will be displayed in `People->Enroll` page.
+- Add support for configuration per installation. We will be able to store the configuration variables of each installation in a single php file and load it everytime we need to make a new deployment or extend the HA of an existing one.
 ### Changed
 - Update email and subject DN when the user logs into registry
 - Use new [EGI theme](https://github.com/EGI-Foundation/comanage-registry-themeegi)

--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -121,3 +121,7 @@ CakeLog::config('error', array(
 	'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
 	'file' => 'error',
 ));
+
+// Change the filename so as to much the file that contains the configuration variables of
+// this deployment
+Configure::load('<deployment>_config.php', 'default');

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -208,11 +208,11 @@ class AppController extends Controller {
       // See if we've collected it from the browser in a previous page load. Otherwise
       // use the system default. If the user set a preferred timezone, we'll catch that below.
       
-      if(!empty($_COOKIE['cm_registry_tz_auto'])) {
+      if(!empty($_COOKIE[Configure::read('cookie_name')])) {
         // We have an auto-detected timezone from a previous page render from the browser.
         // Adjust the default timezone. Actually, don't we want to always record times in UTC.
         //        date_default_timezone_set($_COOKIE['cm_registry_tz_auto']);
-        $this->set('vv_tz', $_COOKIE['cm_registry_tz_auto']);
+        $this->set('vv_tz', $_COOKIE[Configure::read('cookie_name')]);
       } else {
         $this->set('vv_tz', date_default_timezone_get());
       }

--- a/app/Controller/CoEnrollmentFlowsController.php
+++ b/app/Controller/CoEnrollmentFlowsController.php
@@ -368,9 +368,7 @@ class CoEnrollmentFlowsController extends StandardController {
       }
     }
 
-     $url['co'] = $this->cur_co['Co']['id'];
-
-    $this->log(get_class($this)."::{$fn}::url" . $url, LOG_DEBUG);
+    $url['co'] = $this->cur_co['Co']['id'];
     // redirect the user to the url
     $this->redirect($url, null, true);
   }

--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -290,7 +290,8 @@
       var tz = jstz.determine();
       // This won't be available for the first delivered page, but after that the
       // server side should see it and process it
-      document.cookie = "cm_registry_tz_auto=" + tz.name() + "; path=/";
+      cookie_name = "<?php echo(Configure::read('cookie_name')); ?>";
+      document.cookie = cookie_name + "=" + tz.name() + "; path=/";
     </script>
 
 

--- a/app/View/Layouts/lightbox.ctp
+++ b/app/View/Layouts/lightbox.ctp
@@ -68,7 +68,8 @@
       var tz = jstz.determine();
       // This won't be available for the first delivered page, but after that the
       // server side should see it and process it
-      document.cookie = "cm_registry_tz_auto=" + tz.name() + "; path=/";
+      cookie_name = "<?php echo(Configure::read('cookie_name')); ?>";
+      document.cookie = cookie_name + "=" + tz.name() + "; path=/";
     </script>
 
 

--- a/app/webroot/auth/login/index.php
+++ b/app/webroot/auth/login/index.php
@@ -31,7 +31,13 @@
 // Since this page isn't part of the framework, we need to reconfigure
 // to access the Cake session.
 
-session_name("CAKEPHP");
+$sid = "";
+foreach ($_COOKIE as $key => $value){
+  if(strpos($key, "co_registry_sid") !== false){
+    $sid .= $key;
+  }
+}
+session_name($sid);
 session_start();
 
 // Set the user

--- a/app/webroot/auth/logout/index.php
+++ b/app/webroot/auth/logout/index.php
@@ -28,9 +28,15 @@
 // Since this page isn't part of the framework, we need to reconfigure
 // to access the Cake session
 
-session_name("CAKEPHP");
+$sid = "";
+foreach ($_COOKIE as $key => $value){
+  if(strpos($key, "co_registry_sid") !== false){
+    $sid .= $key;
+  }
+}
+session_name($sid);
 session_start();
 
 unset($_SESSION['Auth']);
 
-header("Location: " . "/registry/users/logout");
+header("Location: " . "/registry/Shibboleth.sso/Logout?return=%2Fregistry%2Fpages%2Fpublic%2Floggedout");


### PR DESCRIPTION
1. Single point of reference for cookie and session name. PHP config file for installation configuration variables
2. Changed hard coded string used to find the session name login|logout/index.php so as to much the _something_co_registry_sid naming convention
3. Removing bug from app/Controller/CoEnrollmentFlowsController.php. This is unrelated with the rest of the changes