### PR TITLE
[RCIAM-93] Permission Denied when trying to view linked Org Identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update default CO Person Role entries without linking to a COU if not applicable
 - CO Person's email gets verified during the registration process
 - Add global scope for `Localization` variables of the default CO, COManage. This CO is only accessible by the platform administors.
+- Allow CO Person to view all Org Identities linked to his/her profile

--- a/app/Model/CoPerson.php
+++ b/app/Model/CoPerson.php
@@ -696,6 +696,36 @@ class CoPerson extends AppModel {
   }
 
   /**
+   * Retrieve the org identities linked to a CO Person
+   *
+   * @since  COmanage Registry v3.x.x
+   * @param  integer CO Person Id
+   * @return list of linked org identities or an emtpy array
+   */
+
+  public function orgIdLinksCoPerson($coPersonId) {
+
+    $args['conditions']['CoOrgIdentityLink.co_person_id'] = $coPersonId;
+    $args['joins'][0]['table'] = 'org_identities';
+    $args['joins'][0]['alias'] = 'OrgIdentity';
+    $args['joins'][0]['type'] = 'INNER';
+    $args['joins'][0]['conditions'][0] = 'OrgIdentity.id=CoOrgIdentityLink.org_identity_id';
+    $args['fields'] = array('CoOrgIdentityLink.org_identity_id', 'OrgIdentity.co_id');
+    $args['contain'] = false;
+
+    $link = $this->CoOrgIdentityLink->find('all', $args);
+
+    $linkedOrgIds = array();
+    $tmpEntry = array();
+    foreach ($link as $orgIdentity){
+      $tmpEntry['org_id'] = $orgIdentity['CoOrgIdentityLink']['org_identity_id'];
+      $tmpEntry['co_id'] = $orgIdentity['OrgIdentity']['co_id'];
+      array_push($linkedOrgIds, $tmpEntry);
+    }
+    return $linkedOrgIds;
+  }
+
+  /**
    * Recalculate the status of a CO Person based on the attached CO Person Roles.
    *
    * @since  COmanage Registry v0.9.2


### PR DESCRIPTION
The CO Person gets a Permission Denied message if s/he tries to view any of the linked Org Identities that are not the one used for logging in to his/her profile.
This happens because Comanage uses the information stored in the session and the session has only the one idp used for logging in. 
This pull request returns all the linked OrgIdentities and provide view access to every linked OrgIdentity entry.

