### PR TITLE
[RCIAM-96] Add IdP Source in CO Person's profile(canvas web page) in Organizational Identities table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   - by Description
 - Add search functionality to enrollments flow page. Enrollments can be filtered/sorted by Name
 - Add `hidden` functionality to Enroll page. The Admin can enable the functionality by changing the value of `Hide Enrollment Flow` field to true, in the config page of an Enrollment flow. By default the value is false/empty and all the configured Enrolment Flows will be displayed in `People->Enroll` page.
+- Retrieve AuthenticatingAuthority and depict in CO Person's canvas/profile
+
 ### Changed
 - Update email and subject DN when the user logs into registry
 - Use new [EGI theme](https://github.com/EGI-Foundation/comanage-registry-themeegi)

--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -131,6 +131,7 @@
     <field name="title" type="C" size="128" />
     <field name="o" type="C" size="128" />
     <field name="ou" type="C" size="128" />
+    <field name="authn_authority" type="C" size="1024" />
     <field name="co_id" type="I">
       <constraint>REFERENCES cm_cos(id)</constraint>
     </field>

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1020,6 +1020,7 @@ original notification at
   'fd.affiliation.ep' => 'eduPersonAffiliation',
   'fd.affiliation.ep.map.desc' => 'Map the extended affiliation to this eduPersonAffiliation, see <a href="https://spaces.internet2.edu/display/COmanage/Extending+the+Registry+Data+Model#ExtendingtheRegistryDataModel-%7B%7BeduPersonAffiliation%7D%7DandExtendedAffiliations">eduPersonAffiliation and Extended Affiliations</a>',
   'fd.all' =>         'All',
+  'fd.authn_authority' => 'Authenticating IdP',
   'fd.an.desc' =>     'Alphanumeric characters only',
   'fd.approver' =>    'Approver',
   'fd.archived' =>    'Archived',

--- a/app/Model/OrgIdentity.php
+++ b/app/Model/OrgIdentity.php
@@ -145,6 +145,13 @@ class OrgIdentity extends AppModel {
         'allowEmpty' => true
       )
     ),
+    'authn_authority' => array(
+      'content' => array(
+        'rule' => array('validateInput'),
+        'required' => false,
+        'allowEmpty' => true
+      )
+    ),
 /*    'organization_id' => array(
       'content' => array(
         'rule' => 'numeric',
@@ -542,7 +549,8 @@ class OrgIdentity extends AppModel {
     $newOrgIdentity = null;  // What we decided to save as the updated record (or portion thereof)
     $newModels = array();    // List of associated models we decided to save
     $deleteCert = array();   // List of certificates that are going to be deleted
-    
+    $authnAuthority = isset($_SERVER['AuthenticatingAuthority']) ? $_SERVER['AuthenticatingAuthority'] : null;
+
     foreach($envAttrs as $ea) {
       // First see if there is an env variable identified, and if so if it's populated
       
@@ -593,6 +601,8 @@ class OrgIdentity extends AppModel {
       // in order for SaveAssociated to know what to do).
       
       $newOrgIdentity['OrgIdentity'] = $curOrgIdentity['OrgIdentity'];
+      // Assign the authn_authority value
+      $newOrgIdentity['OrgIdentity']['authn_authority'] = $authnAuthority;
       
       if(!empty($envOrgIdentity['OrgIdentity'])) {
         // Copy each defined field to the record to be saved

--- a/app/View/CoPeople/fields.inc
+++ b/app/View/CoPeople/fields.inc
@@ -1153,7 +1153,10 @@
                     <td>
                       <?php
                         if(!empty($link['OrgIdentity']['OrgIdentitySourceRecord']['OrgIdentitySource']['description'])) {
-                          print filter_var($link['OrgIdentity']['OrgIdentitySourceRecord']['OrgIdentitySource']['description'] ,FILTER_SANITIZE_SPECIAL_CHARS);
+                          print filter_var($link['OrgIdentity']['OrgIdentitySourceRecord']['OrgIdentitySource']['description'] ,FILTER_SANITIZE_SPECIAL_CHARS). "<br>";
+                        }
+                        if(!empty($link['OrgIdentity']['authn_authority'])) {
+                            print filter_var($link['OrgIdentity']['authn_authority'] ,FILTER_SANITIZE_SPECIAL_CHARS). "<br>";
                         }
                       ?>
                     </td>

--- a/app/View/OrgIdentities/fields.inc
+++ b/app/View/OrgIdentities/fields.inc
@@ -420,6 +420,20 @@
           </li>
           <li>
             <div class="field-name">
+              <?php print("Authenticating Authority (IdP)"); ?>
+            </div>
+            <div class="field-info">
+              <?php
+                if(!empty($org_identities[0]['OrgIdentity']['authn_authority'])) {
+                  print filter_var($org_identities[0]['OrgIdentity']['authn_authority'],FILTER_SANITIZE_SPECIAL_CHARS);
+                }else{
+                  print filter_var("UNKNOWN",FILTER_SANITIZE_SPECIAL_CHARS);
+                }
+              ?>
+            </div>
+          </li>
+          <li>
+            <div class="field-name">
               <?php print ($e ? $this->Form->label('ou', _txt('fd.ou')) : _txt('fd.ou')); ?>
             </div>
             <div class="field-info">


### PR DESCRIPTION
This fix enables the extraction of the AthenticationAuthority assertion attribute from the IdP's metadata. Then we store the url by inserting the value into the OrgIdentity table, and finally we depict in the CO Person's profile.

We need to add auth_idp_url column in org_identities table
`alter table cm_org_identities add column authn_authority varchar(1024);`

We need to request from shibboleth SP linked with COManage to fetch the data we need. The configuration should be updated by adding 
```
<!-- Map to extract attributes from SAML assertions. -->
// LEAVE ALL THE OTHER AttributeExtractor entries as is and add the following line
<AttributeExtractor type="Assertion" AuthenticatingAuthority="AuthenticatingAuthority"/>
```

As far as the old users are concerned, the source field will be updated automatically as soon as they use an IdP to log into COManage.