### PR TITLE
RCIAM-96_plus_Idp_source_retrieve_from_metadata_and_view_in_canvas_depict_img_and_FN

### DIFF
--- a/app/View/CoPeople/fields.inc
+++ b/app/View/CoPeople/fields.inc
@@ -312,6 +312,7 @@
   $l = 1;
 ?>
 
+<script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>
 <script type="text/javascript">
   <!-- /* JS specific to these fields */ -->
   
@@ -320,6 +321,20 @@
     var $tabs = $( "#tabs" ).tabs();
     $('#autogenerate-dialog').dialog('open');
   }
+
+  var clipboard = new ClipboardJS('.allowCopy', {
+      text: function(trigger) {
+          return trigger.alt;
+      }
+  });
+
+  clipboard.on('success', function(e) {
+      generateFlash( e.text+" copied to Clipboard.", "success");
+  });
+
+  clipboard.on('error', function(e) {
+      generateFlash( e.text+" failed to copy.", "error");
+  });
 
   $(function() {
     // Explorer menu toggles
@@ -1153,10 +1168,20 @@
                     <td>
                       <?php
                         if(!empty($link['OrgIdentity']['OrgIdentitySourceRecord']['OrgIdentitySource']['description'])) {
-                          print filter_var($link['OrgIdentity']['OrgIdentitySourceRecord']['OrgIdentitySource']['description'] ,FILTER_SANITIZE_SPECIAL_CHARS). "<br>";
+                          print filter_var($link['OrgIdentity']['OrgIdentitySourceRecord']['OrgIdentitySource']['description'] ,FILTER_SANITIZE_SPECIAL_CHARS) . "<br>";
                         }
                         if(!empty($link['OrgIdentity']['authn_authority'])) {
-                            print filter_var($link['OrgIdentity']['authn_authority'] ,FILTER_SANITIZE_SPECIAL_CHARS). "<br>";
+                          $authn_authority = $link['OrgIdentity']['authn_authority'];
+                          $data = $this->Idp->getIdpInfo($link['OrgIdentity']['authn_authority']);
+                          $authnAuthFN = (isset($data['authnAuthFN']) ) ? filter_var($data['authnAuthFN'], FILTER_SANITIZE_SPECIAL_CHARS)
+                                                                        : filter_var($link['OrgIdentity']['authn_authority'] ,FILTER_SANITIZE_SPECIAL_CHARS);
+                          print (isset($data['logoUrl'])) ?
+                                 "<img "
+                                   . "class=\"ois-logo allowCopy\" "
+                                   . "src=\"{$data['logoUrl']}\" "
+                                   . "alt=\"{$authn_authority}\" "
+                                   . "title=\"{$authnAuthFN}\">"
+                                                          : $authnAuthFN;
                         }
                       ?>
                     </td>

--- a/app/View/Helper/IdpHelper.php
+++ b/app/View/Helper/IdpHelper.php
@@ -23,6 +23,8 @@ class IdpHelper extends AppHelper
     curl_setopt($ch, CURLOPT_AUTOREFERER, 1);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
     curl_setopt($ch, CURLOPT_URL, $entityId);    // get the url contents
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 2);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 3);
 
     $xmlData = curl_exec($ch); // execute curl request
     $http_response = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -60,7 +62,6 @@ class IdpHelper extends AppHelper
       }
     }
   }
-
 }
 
 ?>

--- a/app/View/Helper/IdpHelper.php
+++ b/app/View/Helper/IdpHelper.php
@@ -1,0 +1,66 @@
+<?php
+App::uses('AppHelper', 'View/Helper');
+App::uses('Cache', 'Cache');
+
+class IdpHelper extends AppHelper
+{
+
+  public function getIdpInfo($entityId)
+  {
+    $authnAuthFN = null;
+    $logoUrl = null;
+
+    if (empty($entityId) || !filter_var($entityId, FILTER_VALIDATE_URL)) {
+      return null;
+    }
+
+    $data = Cache::read($entityId, '_cake_core_');
+    if ($data !== false)
+      return $data;
+
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_AUTOREFERER, 1);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+    curl_setopt($ch, CURLOPT_URL, $entityId);    // get the url contents
+
+    $xmlData = curl_exec($ch); // execute curl request
+    $http_response = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+    if ($http_response !== 200) {
+      $response = json_decode($xmlData, true);
+      $this->log(__METHOD__ . "::HTTP response code: " . $http_response . ", error message: '" . $response['Error']['Message'], LOG_DEBUG);
+      curl_close($ch);
+      return null;
+    }
+    curl_close($ch);
+
+    $sxe = new SimpleXMLElement($xmlData);
+    $namespaces = $sxe->getNamespaces(true);
+    // TODO: Make namespaces a configuration in a future version
+    if (isset($namespaces['mdui']) && isset($namespaces['xml'])) {
+      $sxe->registerXPathNamespace('mdui', $namespaces['mdui']);
+      $sxe->registerXPathNamespace('xml', $namespaces['xml']);
+      $displayNames = $sxe->xpath('//mdui:DisplayName');
+      $logoUrlObj = $sxe->xpath('//mdui:Logo');
+
+      $displayNamesLangs = $sxe->xpath('//mdui:DisplayName/@xml:lang');
+      foreach ($displayNamesLangs as $key => $lang) {
+        $strLang = (string)$lang['lang'];
+        // Here i can customize the language of choice
+        if ($strLang === "en") {
+          $authnAuthFN = (string)$displayNames[$key];
+          $logoUrl = (string)$logoUrlObj[$key];
+          $data = array();
+          $data['authnAuthFN'] = $authnAuthFN;
+          $data['logoUrl'] = $logoUrl;
+          Cache::write($entityId, $data, '_cake_core_');
+          return $data;
+        }
+      }
+    }
+  }
+
+}
+
+?>

--- a/app/webroot/css/co-base.css
+++ b/app/webroot/css/co-base.css
@@ -1769,6 +1769,13 @@ th, td {
   border-bottom: 2px solid #fff;
   font-weight: normal;
 }
+td img.ois-logo {
+  display: block;
+  max-height: 60px;
+  max-width: 60px;
+  width: auto;
+  height: auto;
+}
 th {
   /*background-color: #9fc6e2;*/
   background-color: #186696;


### PR DESCRIPTION
- Use the stored EntityID URL to retrieve the metadata
- Extract the Friendly name and Logo
- Store the fetched data in Cache
- If no info data are available, then the entityid will get displayed
- If the logo or the friendly name changes, then we should clear cache in order to fetch the new data
- In CO Person's canvas, we depict the Idp's logo and if the user hover's over the logo, the friendly name will be displayed.
- Currently we use 'en' language. We can extend to any supported language if supported by COManage.
- For the social networks hosted by egi's proxy we need to add the appropriate logos. These are available in aai-dev.egi.eu