### PR TITLE
CO1649-fix_to_redirect_users_to_a_meaningful_page_instead_of_logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Allow CO Person to view all Org Identities linked to his/her profile
 - Made the MasterPortal Oauth2 server url a dynamic config option for the RCAuth plugin
 - Fixed broken filtering functionality in relink process
+- Fix to redirect users to a meaningful page instead of logout

--- a/app/Controller/CoInvitesController.php
+++ b/app/Controller/CoInvitesController.php
@@ -386,9 +386,26 @@ class CoInvitesController extends AppController {
         $this->Flash->set($confirm ? _txt('rs.inv.conf') : _txt('rs.inv.dec'), array('key' => 'success'));
       }
       
-      // If a login identifier was provided, force a logout
+      // If a login identifier was provided, redirect to a meaningful page
       if($loginIdentifier) {
-        $this->redirect("/auth/logout");
+        if(!empty($invite['CoInvite']['email_address_id'])) {
+          // if we confirmed an address, review the final result
+
+          $redirect = array(
+            'controller' => 'email_addresses',
+            'action'     => 'view',
+            $invite['CoInvite']['email_address_id']
+          );
+        } else {
+          // Else review the user information
+
+          $redirect = array(
+            'controller' => 'co_people',
+            'action'     => 'canvas',
+            $invite['CoInvite']['co_person_id']
+          );
+        }
+        $this->redirect($redirect);
       } else {
         $this->redirect("/");
       }


### PR DESCRIPTION
- Currently at the end of an Invitation enrollment flow process the user is forced to logout. This fix will remove this problem.
- This fix does not affect account linking and sign up enrollment flows