### PR TITLE
Add Masterportal OP Configuration URL in Comanage RCauth plugin configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - CO Person's email gets verified during the registration process
 - Add global scope for `Localization` variables of the default CO, COManage. This CO is only accessible by the platform administors.
 - Allow CO Person to view all Org Identities linked to his/her profile
+- Made the MasterPortal Oauth2 server url a dynamic config option for the RCAuth plugin

--- a/local/Plugin/RcauthSource/Config/Schema/schema.xml
+++ b/local/Plugin/RcauthSource/Config/Schema/schema.xml
@@ -48,6 +48,7 @@
     <field name="token_type" type="C" size="20" />
     <field name="issuer" type="C" size="256" />
     <field name="idphint" type="C" size="256" />
+    <field name="mp_oa2_server" type="C" size="256" />
     <index name="rcauth_sources_i1">
       <col>org_identity_source_id</col>
       <unique />

--- a/local/Plugin/RcauthSource/Lib/lang.php
+++ b/local/Plugin/RcauthSource/Lib/lang.php
@@ -18,13 +18,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * @link          http://www.internet2.edu/comanage COmanage Project
  * @package       registry-plugin
  * @since         COmanage Registry v2.0.0
  * @license       Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  */
-  
+ 
 global $cm_lang, $cm_texts;
 
 // When localizing, the number in format specifications (eg: %1$s) indicates the argument
@@ -42,6 +42,7 @@ $cm_rcauth_source_texts['en_US'] = array(
 	'er.rcauthsource.search'     => 'Search request returned %1$s',
 	'er.rcauthsource.token.api'  => 'Access token not found in API response',
 	'er.rcauthsource.token.none' => 'Access token not configured (try resaving configuration)',
+	'er.rcauthsource.mp_oa2_server.none' => 'No or invalid MasterPortal OA2 Url. Please check RCAuth OIS configuration',
 
 	// Plugin texts
 	'pl.rcauthsource.clientid'       => 'Client ID',
@@ -54,4 +55,6 @@ $cm_rcauth_source_texts['en_US'] = array(
 	'pl.rcauthsource.issuer.desc'    => 'The DN of the certificate issuer',
 	'pl.rcauthsource.idphint'        => 'IdpHint parameter',
 	'pl.rcauthsource.idphint.desc'   => 'Optionally the VO portal can redirect the user to a specific IdP by also sending an idphint parameter',
+	'pl.rcauthsource.mp_oa2_server'        => 'MasterPortal OP configuration URL',
+	'pl.rcauthsource.mp_oa2_server.desc'   => 'URL of the well known configuration of MasterPortal\'s OP',
 );

--- a/local/Plugin/RcauthSource/Model/RcauthSource.php
+++ b/local/Plugin/RcauthSource/Model/RcauthSource.php
@@ -58,6 +58,11 @@ class RcauthSource extends AppModel {
 			'required' => false,
 			'allowEmpty' => true
 		),
+		'mp_oa2_server' => array(
+			'rule' => array('url', true),
+			'required' => false,
+			'allowEmpty' => true
+		),
 		'issuer' => array(
 			'content' => array(
 				'rule' => array('maxLength', 400),

--- a/local/Plugin/RcauthSource/Model/RcauthSourceBackend.php
+++ b/local/Plugin/RcauthSource/Model/RcauthSourceBackend.php
@@ -18,7 +18,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * @link          http://www.internet2.edu/comanage COmanage Project
  * @package       registry-plugin
  * @since         COmanage Registry v2.0.0
@@ -32,12 +32,28 @@ include_once("mpCfgUrl.php");
 
 class RcauthSourceBackend extends OrgIdentitySourceBackend {
 	public $name = "RcauthSourceBackend";
-	public $rcauthUrl;
+	private $mpOA2Server = null;
 
 	// Constructor
 	function __construct(){
 		parent::__construct();
-		$this->rcauthUrl = new mpCfgUrl();
+	}
+
+	/**
+	 * @param $mpOA2Url   the Url of the Masterportal Oauth2 server of the RCAUTH CA
+	 */
+	public function getMPOPA2endpoints($mpOA2Url){
+		if($this->mpOA2Server == null) {
+			$this->mpOA2Server = new mpCfgUrl($mpOA2Url);
+		}
+	}
+
+	/**
+	 * @return MP Oauth2 Server Server Config Object
+	 */
+	public function getMpOA2Server()
+	{
+		return $this->mpOA2Server;
 	}
 
 	/**
@@ -82,7 +98,7 @@ class RcauthSourceBackend extends OrgIdentitySourceBackend {
 		);
 
 
-		$response = $this->do_curl($this->rcauthUrl->getTokenEndpoint(),$params,$error, $info);
+		$response = $this->do_curl($this->mpOA2Server->getTokenEndpoint(),$params,$error, $info);
 		if(!$this->IsNullOrEmptyString($info['http_code'])){
 			// The request returned successfully. Dump data into an object, check their validity and return
 			// data object from json decode
@@ -219,7 +235,7 @@ class RcauthSourceBackend extends OrgIdentitySourceBackend {
 		//		   "family_name":"Doe",
 		//		   "email":"jdoe@mail.com"
 		//		}
-		$response = $this->do_curl($this->rcauthUrl->getUserinfoEndpoint(),$options,$error, $info);
+		$response = $this->do_curl($this->mpOA2Server->getUserinfoEndpoint(),$options,$error, $info);
 
 		if($info['http_code'] == 404) {
 			// Most likely retrieving an invalid rcauth

--- a/local/Plugin/RcauthSource/Model/mpCfgUrl.php
+++ b/local/Plugin/RcauthSource/Model/mpCfgUrl.php
@@ -28,56 +28,58 @@ class mpCfgUrl {
 	private $idTokenSigningAlgValuesSupported = array();
 
 	// parse json and fill the variables
-	function __construct(){
-		$url = "https://masterportal-pilot.aai.example.org/mp-oa2-server/.well-known/openid-configuration";
-		//  Initiate curl
-		$ch = curl_init();
-		// Disable SSL verification
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
-		// Will return the response, if false it print the response
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		// Set the url
-		curl_setopt($ch, CURLOPT_URL,$url);
-		// Execute
-		$result=curl_exec($ch);
-		// Closing
-		curl_close($ch);
-		$openIdCfgJson = json_decode($result);
-		$this->authorizationEndpoint = $openIdCfgJson->{self::$AUTH_ENDPOINT};
-		$this->registrationEndpoint = $openIdCfgJson->{self::$REGISTER_ENDPOINT};
-		$this->jwksUri = $openIdCfgJson->{self::$JWKS_URI};
-		$this->issuer = $openIdCfgJson->{self::$ISSUER};
-		$this->tokenEndpoint = $openIdCfgJson->{self::$TOKEN_ENDPOINT};
-		$this->userinfoEndpoint = $openIdCfgJson->{self::$USERINFO_ENDPOINT};
+	function __construct($url){
+		// if the url variable has not been defined then do nothing
+		if(isset($url) and $url != "") {
+			//  Initiate curl
+			$ch = curl_init();
+			// Disable SSL verification
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+			// Will return the response, if false it print the response
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			// Set the url
+			curl_setopt($ch, CURLOPT_URL, $url);
+			// Execute
+			$result = curl_exec($ch);
+			// Closing
+			curl_close($ch);
+			$openIdCfgJson = json_decode($result);
+			$this->authorizationEndpoint = $openIdCfgJson->{self::$AUTH_ENDPOINT};
+			$this->registrationEndpoint = $openIdCfgJson->{self::$REGISTER_ENDPOINT};
+			$this->jwksUri = $openIdCfgJson->{self::$JWKS_URI};
+			$this->issuer = $openIdCfgJson->{self::$ISSUER};
+			$this->tokenEndpoint = $openIdCfgJson->{self::$TOKEN_ENDPOINT};
+			$this->userinfoEndpoint = $openIdCfgJson->{self::$USERINFO_ENDPOINT};
 
-		// token_endpoint_auth_methods_supported
-		foreach($openIdCfgJson->{self::$TOKEN_ENDPOINT_AM_SUP} as $data){
-			$this->tokenEndpointAuthMethodsSupported[] = $data;
-		}
+			// token_endpoint_auth_methods_supported
+			foreach ($openIdCfgJson->{self::$TOKEN_ENDPOINT_AM_SUP} as $data) {
+				$this->tokenEndpointAuthMethodsSupported[] = $data;
+			}
 
-		// subject_types_supported
-		foreach($openIdCfgJson->{self::$SUBJECT_TYP_SUP} as $data){
-			$this->subjectTypesSupported[] = $data;
-		}
+			// subject_types_supported
+			foreach ($openIdCfgJson->{self::$SUBJECT_TYP_SUP} as $data) {
+				$this->subjectTypesSupported[] = $data;
+			}
 
-		// scopes_supported
-		foreach($openIdCfgJson->{self::$SCOPES_SUP} as $data){
-			$this->scopesSupported[] = $data;
-		}
+			// scopes_supported
+			foreach ($openIdCfgJson->{self::$SCOPES_SUP} as $data) {
+				$this->scopesSupported[] = $data;
+			}
 
-		// response_types_supported
-		foreach($openIdCfgJson->{self::$RESPONSE_TYP_SUP} as $data){
-			$this->responseTypesSupported[] = $data;
-		}
+			// response_types_supported
+			foreach ($openIdCfgJson->{self::$RESPONSE_TYP_SUP} as $data) {
+				$this->responseTypesSupported[] = $data;
+			}
 
-		// claims_supported
-		foreach($openIdCfgJson->{self::$CLAIMS_SUP} as $data){
-			$this->claimsSupported[] = $data;
-		}
+			// claims_supported
+			foreach ($openIdCfgJson->{self::$CLAIMS_SUP} as $data) {
+				$this->claimsSupported[] = $data;
+			}
 
-		// id_token_signing_alg_values_supported
-		foreach($openIdCfgJson->{self::$ID_TOKEN_SIG_ALG_VAL_SUP} as $data){
-			$this->idTokenSigningAlgValuesSupported[] = $data;
+			// id_token_signing_alg_values_supported
+			foreach ($openIdCfgJson->{self::$ID_TOKEN_SIG_ALG_VAL_SUP} as $data) {
+				$this->idTokenSigningAlgValuesSupported[] = $data;
+			}
 		}
 	}
 

--- a/local/Plugin/RcauthSource/View/RcauthSources/fields.inc
+++ b/local/Plugin/RcauthSource/View/RcauthSources/fields.inc
@@ -81,6 +81,15 @@
   </li>
   <li>
     <div class="field-name">
+      <div class="field-title"><?php print _txt('pl.rcauthsource.mp_oa2_server'); ?></div>
+      <div class="field-desc"><?php print _txt('pl.rcauthsource.mp_oa2_server.desc'); ?></div>
+    </div>
+    <div class="field-info">
+      <?php print ($e ? $this->Form->input('mp_oa2_server', array('size' => 50)) : filter_var($rcauth_sources[0]['RcAuthSource']['mp_oa2_server'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
+    </div>
+  </li>
+  <li>
+    <div class="field-name">
       <div class="field-title">
         <?php print _txt('pl.rcauthsource.clientid'); ?>
         <span class="required">*</span>


### PR DESCRIPTION
We added a new field in the configuration view of RCauth plugin. This field will be used for storing the Masterportal Oauth2 server url. Then we will use the url to fetch the endpoints populated by the service.

Add the required field in the database:
`alter table cm_rcauth_sources add column mp_oa2_server varchar(256);`