### PR TITLE
[RCIAM-57] Users should be redirected to the sp they were trying to log in after registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - IdP hinting for RCAUTH plugin
 - Add support for hiding attributes from the enrollment form. Admins can hide an enrollment flow attribute by setting the value of Hidden from enrollment form view to true in the Enrollment Attribute configuration page. By default the value is false/empty and all the configured Enrolment Attributes will be displayed in the enrollment form.
 - Retrieve AuthenticatingAuthority during user registration
+- Redirect User to the SP after registration. Currently the User was redirected to their COmanage profile view and should go back and reselect the service.
 
 ### Changed
 - Update email and subject DN when the user logs into registry

--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -730,7 +730,7 @@
     <field name="revision" type="I" />
     <field name="deleted" type="L" />
     <field name="actor_identifier" type="C" size="256" />
-        
+    
     <index name="telephone_numbers_i1">
       <col>co_person_role_id</col>
     </index>
@@ -848,7 +848,7 @@
       <col>co_person_id</col>
 <!-- With changelog behavior (CO-1107) this constraint can't be enforced by the database
       <unique />
--->    
+-->
     </index>
     <index name="co_group_members_i4">
       <col>co_group_member_id</col>
@@ -946,7 +946,7 @@
     <field name="cond_status" type="C" size="2" />
     <field name="cond_sponsor_invalid" type="L" />
     <field name="act_affiliation" type="C" size="32" />
-    <field name="act_clear_expiry" type="L" /> 
+    <field name="act_clear_expiry" type="L" />
     <field name="act_cou_id" type="I">
       <constraint>REFERENCES cm_cous(id)</constraint>
     </field>
@@ -1197,7 +1197,7 @@
     <index name="org_identity_sources_i1">
       <col>co_id</col>
     </index>
-     
+    
     <index name="org_identity_sources_i2">
       <col>org_identity_source_id</col>
     </index>
@@ -1525,6 +1525,7 @@
     <field name="revision" type="I" />
     <field name="deleted" type="L" />
     <field name="actor_identifier" type="C" size="256" />
+    <field name="targetnew" type="C" size="1024" />
     
     <index name="co_petitions_i1">
       <col>co_id</col>


### PR DESCRIPTION
- Redirect users to the service they requested after registration. Currently we are redirected in user's COManage profile
- Removed trailing spaces

**This functionality will be in COmanage 3.3 as a core feature.**

Update the schema of the database
alter table cm_co_petitions add column targetnew varchar(1024);