### PR TITLE
[RCIAM-138] Enlist and save authenticating authority attribute during user registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Retrieve AuthenticatingAuthority and depict in CO Person's canvas/profile
 - IdP hinting for RCAUTH plugin
 - Add support for hiding attributes from the enrollment form. Admins can hide an enrollment flow attribute by setting the value of Hidden from enrollment form view to true in the Enrollment Attribute configuration page. By default the value is false/empty and all the configured Enrolment Attributes will be displayed in the enrollment form.
-
+- Retrieve AuthenticatingAuthority during user registration
 
 ### Changed
 - Update email and subject DN when the user logs into registry

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1015,6 +1015,7 @@ original notification at
   'fd.address.fields.req' => 'An address must consist of at least these fields:',
   'fd.admin' =>       'Administrator',
   'fd.ae.optvalue.desc' => 'Permitted value for this attribute',
+  'fd.authn_authority' => 'Authenticating Authority',
   'fd.affil-a' =>     '%1$s Affiliation',
   'fd.affiliation' => 'Affiliation',
   'fd.affiliation.ep' => 'eduPersonAffiliation',

--- a/app/Model/CmpEnrollmentAttribute.php
+++ b/app/Model/CmpEnrollmentAttribute.php
@@ -131,6 +131,13 @@ class CmpEnrollmentAttribute extends AppModel {
         'ldap_name' => 'edu_person_affiliation',
         'saml_name' => 'edu_person_affiliation'
       ),
+      'authn_authority' => array(
+        'required'  => RequiredEnum::Optional,
+        'label'     => _txt('fd.authn_authority'),
+        'env_name'  => 'CMP_EF_AUTHNAUTHORITY',
+        'ldap_name' => '',
+        'saml_name' => 'AuthenticatingAuthority'
+      ),
       'title' => array(
         'required'  => RequiredEnum::Optional,
         'label'     => _txt('fd.title'),

--- a/app/Model/CoEnrollmentAttribute.php
+++ b/app/Model/CoEnrollmentAttribute.php
@@ -220,6 +220,7 @@ class CoEnrollmentAttribute extends AppModel {
       $ret['o:title'] = _txt('fd.title') . " (" . _txt('ct.org_identities.1') . ")";
       $ret['o:o'] = _txt('fd.o') . " (" . _txt('ct.org_identities.1') . ")";
       $ret['o:ou'] = _txt('fd.ou') . " (" . _txt('ct.org_identities.1') . ")";
+      $ret['o:authn_authority'] = _txt('fd.authn_authority') . " (" . _txt('ct.org_identities.1') . ")";
       
       // (6) Multi valued Org Identity attributes, if enabled (code=i)
       // Note that since org identities don't support extended types, we use default values here.


### PR DESCRIPTION
No database change is required.