### PR TITLE
[RCIAM-149] Fixing the issues that caused the wrong depiction of the AuthnAuthority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Select last AuthnAuthority populated through shibboleth
 - Fixed the redirect url created by CO Groups Search functionality
 - Fixed redirect controller after email verification for an OrgIdentity
+- When multiple idps are included in the request data, as a unified string with a semicolon delimiter, we do not parse them properly in order to retrieve only the last idp
+- The update of the AuthnAuthority attribute gets overwritten by the old value
+- Attribute string length to 256 characters, so as to much the max size of an Entity Id

--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -1560,7 +1560,7 @@
       <constraint>REFERENCES cm_co_enrollment_attributes(id)</constraint>
     </field>
     <field name="attribute" type="C" size="80" />
-    <field name="value" type="C" size="160" />
+    <field name="value" type="C" size="256" />
     <field name="attribute_foreign_key" type="I" />
     <field name="created" type="T" />
     <field name="modified" type="T" />

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1021,7 +1021,6 @@ original notification at
   'fd.affiliation.ep' => 'eduPersonAffiliation',
   'fd.affiliation.ep.map.desc' => 'Map the extended affiliation to this eduPersonAffiliation, see <a href="https://spaces.internet2.edu/display/COmanage/Extending+the+Registry+Data+Model#ExtendingtheRegistryDataModel-%7B%7BeduPersonAffiliation%7D%7DandExtendedAffiliations">eduPersonAffiliation and Extended Affiliations</a>',
   'fd.all' =>         'All',
-  'fd.authn_authority' => 'Authenticating IdP',
   'fd.an.desc' =>     'Alphanumeric characters only',
   'fd.approver' =>    'Approver',
   'fd.archived' =>    'Archived',

--- a/app/Model/CoPetition.php
+++ b/app/Model/CoPetition.php
@@ -1512,6 +1512,13 @@ class CoPetition extends AppModel {
     // Start a transaction
     $dbc = $this->getDataSource();
     $dbc->begin();
+
+    // RCIAM-149: Here we save the attributes during petition
+    if(isset($requestData['EnrolleeOrgIdentity']['authn_authority'])){
+      $authnIdps = explode(";", $requestData['EnrolleeOrgIdentity']['authn_authority']);
+      $authnAuthority = end($authnIdps);
+      $requestData['EnrolleeOrgIdentity']['authn_authority'] = $authnAuthority;
+    }
     
     // Walk through the request data and validate it manually. We have to do it this
     // way because it's possible for an enrollment flow to define (say) two addresses,

--- a/app/Model/OrgIdentity.php
+++ b/app/Model/OrgIdentity.php
@@ -605,8 +605,6 @@ class OrgIdentity extends AppModel {
       // in order for SaveAssociated to know what to do).
       
       $newOrgIdentity['OrgIdentity'] = $curOrgIdentity['OrgIdentity'];
-      // Assign the authn_authority value
-      $newOrgIdentity['OrgIdentity']['authn_authority'] = $authnAuthority;
       
       if(!empty($envOrgIdentity['OrgIdentity'])) {
         // Copy each defined field to the record to be saved
@@ -628,6 +626,9 @@ class OrgIdentity extends AppModel {
           }
         }
       }
+
+      // Assign the authn_authority value
+      $newOrgIdentity['OrgIdentity']['authn_authority'] = $authnAuthority;
       
       // We don't want to save models which have no associated env data, so iterate
       // through the models defined by the contain and check.


### PR DESCRIPTION
Resolving two issues:
* the first one is that when multiple idps are included in the request data, as a unified string with a semicolon delimiter, we do not parse them properly in order to retrieve only the last idp
* the second one is that the update of the AuthnAuthority attribute gets overwritten by the old value
* removing duplicate value from lang.php

Database change:
`BEGIN;alter table cm_co_petition_attributes alter column value type varchar(256);COMMIT;`

