### PR TITLE
Backport bootstrap php plugin load config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Update email and subject DN when the user logs into registry
 - Use new [EGI theme](https://github.com/EGI-Foundation/comanage-registry-themeegi)
+- Changed the way we load plugins from config. This extention will allow plugins to inject bootstrapping and routes
 
 ### Fixed
 - Prevent users from submitting multiple registration requests

--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -84,7 +84,13 @@ _bootstrap_plugin_enum();
 include APP."Lib/lang.php";
 include APP."Lib/util.php";
 
-CakePlugin::loadAll();
+// Allow plugins to inject bootstrapping and routes
+// Contrary to the documentation, this needs to be an array of an array
+CakePlugin::loadAll(array(array(
+  'ignoreMissing' => true,
+  'bootstrap'     => true,
+  'routes'        => true
+)));
 
 /**
  * You can attach event listeners to the request lifecyle as Dispatcher Filter . By Default CakePHP bundles two filters:


### PR DESCRIPTION
Updated boostrap.php config file.Allow plugins to inject bootstrapping and routes
REF:https://github.com/Internet2/comanage-registry/blob/develop/app/Config/bootstrap.php