### PR TITLE
RCIAM-197 Authenticating Authority should be updated during Invite after a Linking EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,3 +73,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - CO Level custom Themes had no effect on Invitation pages during and Enrollment Flow
 - Fix hardcoded intro message in invitation acceptance page.Added as Enrollment Flow Configuration.
 - Redirect directly to the configured Plugin, if the Enrollment Flow step is optional
+- Authenticated Authority did not set properly during an IdP linking Enrollment Flow

--- a/app/Model/CoInvite.php
+++ b/app/Model/CoInvite.php
@@ -180,6 +180,16 @@ class CoInvite extends AppModel {
               if(isset($cp_email['EmailAddress']['id'])){
                 $this->CoPerson->EmailAddress->verify(null, $invite['CoInvite']['co_person_id'], $invite['CoInvite']['mail'], $invite['CoPetition']['enrollee_co_person_id']);
               }
+
+              // RCIAM-197
+              $authn_authority = getenv('AuthenticatingAuthority');
+              if(!empty($authn_authority)){
+                $authnIdps = explode(";", $authn_authority);
+                $authnAuthority = end($authnIdps);
+                $this->OrgIdentity = ClassRegistry::init('OrgIdentity');
+                $this->OrgIdentity->id = $orgId;
+                $this->OrgIdentity->saveField('authn_authority', $authnAuthority);
+              }
             }
             catch(Exception $e) {
               $dbc->rollback();


### PR DESCRIPTION
An Identity Linking EOF in COmanage has two steps. The Enrollee step and the Invitee step. During the Enrollee step the registry collects all the ENV variables from the existing user's IdP. This results in having false value for the attribute of AuthenticatingAuthority. As a result, we should update the value as soon as we relogin through the new IdP.