### PR TITLE
Fetch_COU_groups_related_data_via_REST

### DIFF
--- a/app/Controller/CoGroupsController.php
+++ b/app/Controller/CoGroupsController.php
@@ -289,31 +289,42 @@ class CoGroupsController extends StandardController {
    *
    * @since  COmanage Registry v0.6
    */
-  
+
   function index() {
-    if($this->request->is('restful') && !empty($this->params['url']['copersonid'])) {
-      // We need to retrieve via a join, which StandardController::index() doesn't
-      // currently support.
-      
-      try {
+    $this->log(__METHOD__ ."::@ ", LOG_DEBUG);
+
+    // If this is not a restful call. Load the parent behavior and return
+    if(!$this->request->is('restful')) {
+      parent::index();
+      return;
+    }
+    try {
+      // The rest refers to a RESTful behavior.
+      if(!empty($this->params['url']['copersonid'])) {
+        // We need to retrieve via a join, which StandardController::index() doesn't
+        // currently support.
         $groups = $this->CoGroup->findForCoPerson($this->params['url']['copersonid']);
-        
-        if(!empty($groups)) {
-          $this->set('co_groups', $this->Api->convertRestResponse($groups));
-        } else {
-          $this->Api->restResultHeader(204, "CO Person Has No Groups");
-          return;
-        }
+        $err_msg = "CO Person has no Groups";
+      } elseif (!empty($this->params['url']['coid']) && !empty($this->params['url']['couid']) ) {
+        $admin = !empty($this->params['url']['admin']) ? $this->params['url']['admin'] : false;
+        $groups = $this->CoGroup->findForCou( $this->params['url']['coid'], $this->params['url']['couid'], $admin);
+        $err_msg = "CO and COU combination returned no group";
       }
-      catch(InvalidArgumentException $e) {
-        $this->Api->restResultHeader(404, "CO Person Unknown");
+
+      if(!empty($groups)) {
+        $groups_response = $this->Api->convertRestResponse($groups);
+        $this->set('co_groups', $groups_response);
+      } else {
+        $this->Api->restResultHeader(204, $err_msg);
         return;
       }
-    } else {
-      parent::index();
+    }
+    catch(InvalidArgumentException $e) {
+      $this->Api->restResultHeader(404, "Error:" . $e->getMessage());
+      return;
     }
   }
-  
+
   /**
    * Authorization for this Controller, called by Auth component
    * - precondition: Session.Auth holds data used for authz decisions

--- a/app/Model/CoGroup.php
+++ b/app/Model/CoGroup.php
@@ -394,7 +394,31 @@ class CoGroup extends AppModel {
     
     throw new InvalidArgumentException(_txt('er.gr.nf', array($args['conditions']['CoGroup.name'])));
   }
-  
+
+    /**
+   * Obtain all groups for a COU.
+   *
+   * @since  COmanage Registry v3.0.0
+   * @param  Integer CO ID
+   * @param  Integer COU ID
+   * @param  Boolean Whether to return admin only record
+   * @return Array Group information, as returned by find
+   */
+
+  function findForCou($coId, $couId, $admin=false) {
+    $args = array();
+    $args['conditions']['CoGroup.co_id'] = $coId;
+    // For the CO Admin group, $couId must be null
+    $args['conditions']['CoGroup.cou_id'] = $couId;
+    if($admin) {
+      $args['conditions']['CoGroup.group_type'] = GroupEnum::Admins;
+    }
+    $args['conditions']['CoGroup.status'] = SuspendableStatusEnum::Active;
+    $args['contain'] = false;
+
+    return $this->Co->CoGroup->find('all', $args);
+  }
+
   /**
    * Actions to take before a save operation is executed.
    *


### PR DESCRIPTION
Extended CoGroups API:
1. Fetch all groups of a COU that belongs to a CO
2. Fetch only the admin group of a the COU