### PR TITLE
[RCIAM-220] Increased COLocalization text capacity and text field to textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update email and subject DN when the user logs into registry
 - Use new [EGI theme](https://github.com/EGI-Foundation/comanage-registry-themeegi)
 - Changed the way we load plugins from config. This extention will allow plugins to inject bootstrapping and routes
+- Increased CO Localization text field capacity.
 
 ### Fixed
 - Prevent users from submitting multiple registration requests

--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -2126,7 +2126,7 @@
     <!-- mysql doesn't want a column called "key" -->
     <field name="lkey" type="C" size="40" />
     <field name="language" type="C" size="16" />
-    <field name="text" type="C" size="256" />
+    <field name="text" type="C" size="512" />
     
     <index name="co_localizations_i1">
       <col>co_id</col>

--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -113,6 +113,10 @@ Configure::write('Dispatcher.filters', array(
 	'CacheDispatcher'
 ));
 
+
+// Add a custom confirmation logout page. The path should be under Views/pages/public/mycustomlogout.ctp
+// Configure::write('confirmationLogout.path', '/pages/public/mycustomlogout');
+
 /**
  * Configures default file logging options
  */

--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -1459,7 +1459,7 @@ class CoPetitionsController extends StandardController {
         // Default redirect is to /, which isn't really a great target
         
         $this->Flash->set(_txt('rs.pt.create.self'), array('key' => 'success'));
-        $targetUrl = "/";
+        $targetUrl = !empty(Configure::read('confirmationLogout.path')) ? Configure::read('confirmationLogout.path') : "/";
       }
       // else we suppress the flash message, since it may not make sense in context
       // or may appear "randomly" (eg: if the targetUrl is outside the Cake framework)

--- a/app/View/CoLocalizations/fields.inc
+++ b/app/View/CoLocalizations/fields.inc
@@ -126,7 +126,7 @@
     </div>
     <div class="field-info">
       <?php print ($e
-                   ? $this->Form->input('text', array('size' => '80','class' => 'focusFirst'))
+                   ? $this->Form->input('text', array('size' => '512','class' => 'focusFirst', 'type' => 'textarea'))
                    : filter_var($co_localizations[0]['CoLocalization']['text'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
     </div>
   </li>


### PR DESCRIPTION
- Increased the text field capacity to 512 characters
- Changed the html text element to a textarea element

MUST update the database:
`alter table cm_co_localizations alter column text type varchar(512);`