### PR TITLE
Fix_regex_PCRE_group_error

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -913,7 +913,7 @@ class DboSource extends DataSource {
 				)
 			);
 		}
-		if (preg_match('/^[\w-_\s]*[\w-_]+/', $data)) {
+		if (preg_match('/^[\w\s_-]*[\w_-]+/', $data)) {
 			return $this->cacheMethod(__FUNCTION__, $cacheKey, $this->startQuote . $data . $this->endQuote);
 		}
 		return $this->cacheMethod(__FUNCTION__, $cacheKey, $data);


### PR DESCRIPTION
- Fixed regex in order to pass the new PCRE(regular expression library PHP uses)

In newer versions of PHP during the initial setup of COmanage we get a regex warning. The regex does not validate for the new PCRE. This can be confirmed [here](https://www.debuggex.com) and [here](https://stackoverflow.com/questions/24764212/preg-match-compilation-failed-invalid-range-in-character-class-at-offset).
This is does not(?) seem to be a fatal error but it is confusing for the administrator.  It makes the automation to fail and a verbose warning message is printed on screen.