### PR TITLE
Redirect_SP_url_not_present_in_plugin

### DIFF
--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -752,6 +752,10 @@ class CoPetitionsController extends StandardController {
             'controller' => Inflector::underscore($plugins[$i]) . '_co_petitions',
             'action'     => $step
           );
+          // Redirect to the plugin taking the query params with you
+          if ($step == 'start' && !empty($this->request->query)) {
+              $redirect['?'] = $this->request->query;
+          }
           
           // Append petition ID or enrollment flow ID according to what we know
           if($id) {


### PR DESCRIPTION
When loading the plug-ins during the enrolment flow the query parameters were not propagated. With this fix we propagate all the query parameters into the COmanage plug-in for further handling.

**Backporting/Cross checked from/with COmanage develop branch**