### PR TITLE
CO-1605_Terms_and_Conditions_content_field

### DIFF
--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -2067,6 +2067,7 @@
     </field>
     <field name="description" type="C" size="256" />
     <field name="url" type="C" size="256" />
+    <field name="body" type="X" size="4000" />
     <field name="cou_id" type="I">
       <constraint>REFERENCES cm_cous(id)</constraint>
     </field>

--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -476,6 +476,7 @@ class CoPetitionsController extends StandardController {
                                        ->CoEnrollmentFlow
                                        ->CoEnrollmentAttribute
                                        ->mapEnvAttributes($enrollmentAttributes, array());
+          $enrollmentAttributes_attributes = Hash::combine($enrollmentAttributes, '{n}.attribute', '{n}.default');
         }
         
         $this->set('co_enrollment_attributes', $enrollmentAttributes);
@@ -497,9 +498,13 @@ class CoPetitionsController extends StandardController {
                                                             array('CoEnrollmentFlow.id' => $enrollmentFlowID));
         
         if($authn || $authz != EnrollmentAuthzEnum::None) {
+          $cou_id = (array_key_exists('r:cou_id', $enrollmentAttributes_attributes))
+                    ? $enrollmentAttributes_attributes['r:cou_id']
+                    : null;
+
           $tArgs = array();
           $tArgs['conditions']['CoTermsAndConditions.co_id'] = $this->cur_co['Co']['id'];
-          $tArgs['conditions']['CoTermsAndConditions.cou_id'] = null;
+          $tArgs['conditions']['CoTermsAndConditions.cou_id'] = $cou_id;
           $tArgs['conditions']['CoTermsAndConditions.status'] = SuspendableStatusEnum::Active;
           $tArgs['contain'] = false;
           

--- a/app/Controller/CoTermsAndConditionsController.php
+++ b/app/Controller/CoTermsAndConditionsController.php
@@ -195,10 +195,34 @@ class CoTermsAndConditionsController extends StandardController {
     // Modify ordering for display via AJAX
     $p['reorder'] = ($roles['cmadmin'] || $roles['coadmin']);
 
+    // A raw view of the T&C content is always allowed
+    $p['display']=true;
+
     $this->set('permissions', $p);
     return $p[$this->action];
   }
-  
+
+  /**
+   * Display the T&C body text
+   * Necessary to enable viewing of T&C as stored in the database. This
+   * conveniently provides a valid URL to place in the relevant URL field
+   * of the T&C model, if no other value is available.
+   *
+   * @since  COmanage Registry v3.2.0
+   * @param  Integer $id CO Terms and Agreements identifier
+   * @return void
+   */
+
+  public function display($id) {
+    $args = array();
+    $args['conditions'][$this->modelClass.'.id'] = $id;
+
+    $tc = $this->CoTermsAndConditions->find('first', $args);
+
+    $this->layout='raw';
+    $this->set("body",$tc[$this->modelClass]['body']);
+  }
+
   /**
    * Pull T&C for review
    * - precondition: The named parameter 'copersonid' is populated with the target CO Person ID

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1448,6 +1448,8 @@ original notification at
   'fd.tc.agree.no' => 'Not Agreed',
   'fd.tc.agree.yes' => 'Agreed',
   'fd.tc.archived' => 'The definition of this T&C changed after the agreement was recorded',
+  'fd.tc.body' => 'Inline T&C',
+  'fd.tc.body.desc' => 'Terms and Conditions for inline rendering. If provided, overrides and overwrites the URL',
   'fd.tc.cou.desc' => 'If set, this T&C only applies to members of the specified COU',
   'fd.tc.for' =>      'Terms and Conditions for %1$s (%2$s)',
   'fd.tc.mode.login' => 'Terms and Conditions Mode',

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -1375,4 +1375,23 @@ class AppModel extends Model {
     
     return $ret;
   }
+
+  /**
+   * Validate that at least one of the named fields contains a value.
+   *
+   * @since  COmanage Registry vTODO
+   * @param  string field Name of field within model, as known to $validates
+   * @param  array fields List of field names to match
+   * @return array Array suitable for generating a select via FormHelper
+   */
+  public function validateOneOfMany($field, $fields) {
+    $status = false;
+    foreach($fields as $name) {
+      if(!empty($this->data[$this->alias][$name])) {
+        $status = true;
+        break;
+      }
+    }
+    return $status;
+  }
 }

--- a/app/Model/CoTermsAndConditions.php
+++ b/app/Model/CoTermsAndConditions.php
@@ -50,10 +50,16 @@ class CoTermsAndConditions extends AppModel {
       'allowEmpty' => false
     ),
     'url' => array(
-      'rule' => array('url', true),
-      'required' => true,
-      'allowEmpty' => false,
-      'message' => 'A URL must be provided'
+      'rule' => array("validateOneOfMany", array("url","body")),
+      'required' => false,
+      'type' => 'textarea',
+      'message' => "" // empty message causes field to get error state without duplicate message
+    ),
+    'body' => array(
+      'rule' => array("validateOneOfMany", array("url","body")),
+      'required' => false,
+      'type' => 'textarea',
+      'message' => 'Either URL or Content must be set for this T&C'
     ),
     'cou_id' => array(
       'rule' => 'numeric',
@@ -202,6 +208,39 @@ class CoTermsAndConditions extends AppModel {
       $this->data['CoTermsAndConditions']['ordr'] = $n;
     }
 
+    // if we have a body for our T&C, override any URL with a local
+    // URL to display said body
+    if (!empty($this->data['CoTermsAndConditions']['body'])) {
+      $this->data['CoTermsAndConditions']['url'] = Router::url(array(
+                             "controller" => "CoTermsAndConditions",
+                             "action" => "display",
+                             $this->data['CoTermsAndConditions']['id']
+                           ), true);
+    }
+
     return true;
   }
+
+  /**
+   * Actions to take after a save operation is executed.
+   *
+   * @since  COmanage Registry v3.2.0
+   */
+
+  public function afterSave($created, $options = array()) {
+
+    // if we created a new T&C and added a URL pointing to our T&C body,
+    // we need to re-save the model with the newly created model id
+    if($created && !empty($this->data['CoTermsAndConditions']['body'])) {
+      $this->data['CoTermsAndConditions']['url'] = Router::url(array(
+                             "controller" => "CoTermsAndConditions",
+                             "action" => "display",
+                             $this->data['CoTermsAndConditions']['id']
+                           ), true);
+      $this->save();
+    }
+
+    return true;
+  }
+  
 }

--- a/app/View/CoTermsAndConditions/display.ctp
+++ b/app/View/CoTermsAndConditions/display.ctp
@@ -1,0 +1,1 @@
+<?php echo $body; ?>

--- a/app/View/CoTermsAndConditions/fields.inc
+++ b/app/View/CoTermsAndConditions/fields.inc
@@ -96,14 +96,26 @@
       <div class="field-name">
         <div class="field-title">
           <?php print ($e ? $this->Form->label('url', _txt('fd.url')) : _txt('fd.url')); ?>
-          <span class="required">*</span>
         </div>
         <div class="field-desc"><?php print _txt('fd.tc.url.desc'); ?></div>
       </div>
       <div class="field-info">
         <?php print ($e
-                     ? $this->Form->input('url', array('size' => '60'))
+                     ? $this->Form->input('url', array('size' => '60', 'required'=>false))
                      : filter_var($co_terms_and_conditions[0]['CoTermsAndConditions']['url'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
+      </div>
+    </li>
+    <li class="field-stack">
+      <div class="field-name">
+        <div class="field-title">
+          <?php print ($e ? $this->Form->label('tc_body', _txt('fd.tc.body')) : _txt('fd.tc.body')); ?>
+        </div>
+        <span class="descr"><?php print _txt('fd.tc.body.desc'); ?></span>
+      </div>
+      <div class="field-info">
+        <?php print ($e
+                     ? $this->Form->input('body', array('required'=>false))
+                     : filter_var($co_terms_and_conditions[0]['CoTermsAndConditions']['body'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
       </div>
     </li>
     <li>

--- a/app/View/Layouts/raw.ctp
+++ b/app/View/Layouts/raw.ctp
@@ -1,0 +1,28 @@
+<?php
+/**
+ * COmanage Registry Raw Layout
+ *
+ * Portions licensed to the University Corporation for Advanced Internet
+ * Development, Inc. ("UCAID") under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * UCAID licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @link          http://www.internet2.edu/comanage COmanage Project
+ * @package       registry
+ * @since         COmanage Registry v3.2.0
+ * @license       Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ */
+
+print $this->fetch('content');


### PR DESCRIPTION
- This fix adds the field and creates a local URL to display the HTML content
- Generic validation on AppModel, added raw layout to allow displaying only T&C body content without exitting prematurely, added beforeSave and afterSave checks to override and overwrite the T&C URL content
- Updated raw Layout to include license header

```sql
alter table cm_co_terms_and_conditions add column body text;
```