### PR TITLE
CO-700_COU-Specific_Terms_and_Conditions_In_CO_Petition_RCIAM31X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Retrieve AuthenticatingAuthority during user registration
 - Redirect User to the SP after registration. Currently the User was redirected to their COmanage profile view and should go back and reselect the service.
 - Spinner in blank View during authentication redirect from Proxy
+- Apply VO specific Terms & Conditions when enrolling to the VO
 
 ### Changed
 - Update email and subject DN when the user logs into registry


### PR DESCRIPTION
- Show COU level T&C if available
  - if we suspend the T&C nothing will be presented to the user
- If no T&C are configured for the COU fetch the ones from the CO
  - Accepting the ones from CO will not update the acceptance date stored in the database or result in a duplicate entry
