### PR TITLE
CO-1988_provisioning_plugin_delete_bug_CO-1982_custom_themes_ui_bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix wrong progress calculation during Enrollment
 - Fix UI Themes do not apply for Invitation Views
 - Members of Closed Group could not access the View Page of the Group
+- Fix custom UI Themes should not apply to COPetition View page
+- Fix fatal error when deleting Provisioning Plugins

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -804,8 +804,9 @@ class AppController extends Controller {
     
     if(!empty($this->cur_co['Co']['id'])) {
       // First see if we're in an enrollment flow
-      if($this->name === 'CoPetitions'
-         || $this->name === 'CoInvites') {
+      if(($this->name === 'CoPetitions'
+          && $this->view !== 'view')
+          || $this->name === 'CoInvites') {
         $efId = $this->enrollmentFlowID();
         
         if($efId > -1) {

--- a/app/Controller/CoProvisioningTargetsController.php
+++ b/app/Controller/CoProvisioningTargetsController.php
@@ -97,7 +97,7 @@ class CoProvisioningTargetsController extends StandardController {
    * @param  Array Current data
    * @return boolean true if dependency checks succeed, false otherwise.
    */
-  
+
   function checkDeleteDependencies($curdata) {
     // Annoyingly, the read() call in standardController resets the associations made
     // by the bindModel() call in beforeFilter(), above. Beyond that, deep down in
@@ -111,6 +111,10 @@ class CoProvisioningTargetsController extends StandardController {
       $model = "Co" . $plugin . "Target";
       
       if(!empty($curdata[$model]['id'])) {
+        // Remove the plugin object from the instance and enforce a new one
+        if(!empty(ClassRegistry::getObject($model))) {
+          ClassRegistry::removeObject($model);
+        }
         $this->loadModel($plugin . "." . $model);
         $this->$model->delete($curdata[$model]['id']);
       }


### PR DESCRIPTION
- UI custom Themes should not apply to CO Petition View pages.
- Deleting of Provisioning plug-ins with dependent true relationship caused fatal error.