### PR TITLE
RCIAM-303_Show_whole_tree_for_cous_ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Increased CO Localization text field capacity.
 - Improved user's graphical interaction during Enrollment Flow
 - Redirect User to CO dashboard if member in only one CO.
+- Show whole tree for nested COUs at the `Add a New CO Person Role` form
 
 ### Fixed
 - Prevent users from submitting multiple registration requests

--- a/app/Controller/CoPersonRolesController.php
+++ b/app/Controller/CoPersonRolesController.php
@@ -556,7 +556,12 @@ class CoPersonRolesController extends StandardController {
     if($roles['cmadmin'] || $roles['coadmin']) {
       // Note that here we get id => name while in CoPeopleController we just
       // get a list of names. This is to generate the pop-up on the edit form.
-      $p['cous'] = $this->CoPersonRole->Cou->allCous($this->cur_co['Co']['id']);
+      $cous = $this->CoPersonRole->Cou->find('threaded',array('conditions' => array("Cou.co_id" => $this->cur_co['Co']['id'])));
+      $childCous = array();
+      foreach($cous as $cou) {
+        $childCous = array_unique($childCous + $this->CoPersonRole->Cou->childCousById($cou['Cou']['id'], true, $cou));
+      }
+      $p['cous'] = $childCous;
     } elseif(!empty($roles['admincous'])) {
       $p['cous'] = $roles['admincous'];
     } else {
@@ -622,7 +627,7 @@ class CoPersonRolesController extends StandardController {
     $this->set('permissions', $p);
     return $p[$this->action];
   }
-  
+
   /**
    * Perform a redirect back to the controller's default view.
    * - postcondition: Redirect generated


### PR DESCRIPTION
Show the whole tree of a cou, seperated by " / " (e.g parent / child / subchild) when adding person to a cou. 
Related issue : https://jira.argo.grnet.gr/browse/RCIAM-303