### PR TITLE
CO-2029_Enroller_plugin_start_hook_is_not_firing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Hide left menu, user top menu, breadcrumbs during Enrollment Flow
 - CO Level custom Themes had no effect on Invitation pages during and Enrollment Flow
 - Fix hardcoded intro message in invitation acceptance page.Added as Enrollment Flow Configuration.
+- Redirect directly to the configured Plugin, if the Enrollment Flow step is optional

--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -864,6 +864,10 @@ class CoPetitionsController extends StandardController {
           
           // Make sure we don't issue a redirect
           return;
+        } elseif($steps[$step]['enabled'] == RequiredEnum::Optional) {
+          // Redirect into the plugins to see if any want to run
+
+          $this->redirect($onFinish);
         }
       }
     }


### PR DESCRIPTION
Redirect to any enable plugin if the step is enabled in Optional mode