### PR TITLE
BUG_petition_attribute_is_too_small

### DIFF
--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -1563,7 +1563,7 @@
       <constraint>REFERENCES cm_co_enrollment_attributes(id)</constraint>
     </field>
     <field name="attribute" type="C" size="80" />
-    <field name="value" type="C" size="256" />
+    <field name="value" type="C" size="512" />
     <field name="attribute_foreign_key" type="I" />
     <field name="created" type="T" />
     <field name="modified" type="T" />


### PR DESCRIPTION
Changed string length from 256 to 512 in the Database configuration file.

```sql
alter table cm_co_petition_attributes alter column value type varchar(512) using value::varchar(512);
```