### PR TITLE
cou admin to add subcous

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -937,7 +937,7 @@ class AppController extends Controller {
     $p['menu']['coattrenums'] = $roles['cmadmin'] || $roles['coadmin'];
     
     // Manage any CO configuration?
-    $p['menu']['coconfig'] = $roles['cmadmin'] || $roles['coadmin'];
+    $p['menu']['coconfig'] = $roles['cmadmin'] || $roles['coadmin'] || $roles['couadmin'];
     
     // View CO departments?
     $p['menu']['codepartments'] = $roles['cmadmin'];
@@ -980,7 +980,7 @@ class AppController extends Controller {
     $p['menu']['idvalidate'] = $roles['cmadmin'] || $roles['coadmin'];
     
     // Manage COU definitions?
-    $p['menu']['cous'] = $roles['cmadmin'] || $roles['coadmin'];
+    $p['menu']['cous'] = $roles['cmadmin'] || $roles['coadmin'] || $roles['couadmin'];
 
     // Manage CO Email Lists
     $p['menu']['colists'] = $roles['cmadmin'] || $roles['coadmin'];

--- a/app/Controller/CoDashboardsController.php
+++ b/app/Controller/CoDashboardsController.php
@@ -122,7 +122,7 @@ class CoDashboardsController extends StandardController {
     // Determine what operations this user can perform
     
     // Lock down the configuration dashboard to only cmadmin and coadmin for now (might change in future)
-    $p['configuration'] = ($roles['cmadmin'] || $roles['coadmin']);
+    $p['configuration'] = ($roles['cmadmin'] || $roles['coadmin'] || $roles['couadmin']);
     
     // View the dashboard for the specified CO?
     $p['dashboard'] = ($roles['cmadmin'] || $roles['coadmin'] || $roles['comember']);

--- a/app/Model/Cou.php
+++ b/app/Model/Cou.php
@@ -26,6 +26,7 @@
  */
   
 class Cou extends AppModel {
+
   // Define class name for cake
   public $name = "Cou";
   
@@ -188,7 +189,7 @@ class Cou extends AppModel {
    * @return Array Array of [id] => [name]
    */
   
-  public function potentialParents($currentCou, $coId) {
+  public function potentialParents($currentCou, $coId, $groupAdmin = FALSE, $returnOptionArray = FALSE) {
     // Editing an existing COU requires removing it and its children from the list of potential parents
     if($currentCou) {
       // Find this COU and its children
@@ -212,14 +213,28 @@ class Cou extends AppModel {
     } else {
       $conditions = array();
       $conditions['Cou.co_id'] = $coId;
+      if($groupAdmin !== FALSE) {
+        $joins[0]['table'] = 'co_groups';
+        $joins[0]['alias'] = 'CoGroups';
+        $joins[0]['type'] = 'INNER';
+        $joins[0]['conditions'][0] = 'Cou.id=CoGroups.cou_id';
+        $conditions['CoGroups.id'] = $groupAdmin;
+        
+      } 
     }
     
     $args = array();
     $args['conditions'] = $conditions;
+    if(!empty($joins)){
+      $args['joins'] = $joins;
+    }
     $args['contain'] = false;
     
     // Create options list all other COUS in CO
     $optionArrays = $this->find('all', $args);
+    if($returnOptionArray){
+      return $optionArrays;
+    }
     $optionList = Set::combine($optionArrays, '{n}.Cou.id','{n}.Cou.name');
     
     return $optionList;

--- a/app/View/CoGroups/index.ctp
+++ b/app/View/CoGroups/index.ctp
@@ -356,8 +356,8 @@
             $e = $permissions['edit'];
             $v = $permissions['view'] || $c['CoGroup']['open'];
 
-            if(!empty($permissions['owner'])
-               && in_array($c['CoGroup']['id'], $permissions['owner'])) {
+            if((!empty($permissions['owner']) && in_array($c['CoGroup']['id'], $permissions['owner'])) 
+            || in_array($c['CoGroup']['id'], $permissions['admingroups'])) {
               $d = true;
               $e = true;
             }


### PR DESCRIPTION
Some issues to be resolved:
1. List COUs: What we want to show here?? COUs that user is owner-admin (via group membership)? Or what $roles['admincous'] contains (shows the children of COUs is admin)? .eg if you are admin in AMB then $roles['admincous'] contains also the children of AMB. I
2. When adding a COU, at parent list, what do we want to show? (Same as above)
3. When adding a COU, the couadmin can't put himself as admin to that group.. What I implemented is to give him access to add himself as an admin to groups that are connected to cous that are inside $roles['admincous']
4. When editing a COU I havent yet implemented the parent list.

Also i couldnot avoid adding index() function for listing COUs as "cous" is set at Standard Controller:
line 1013  $this->set($modelpl, $this->Paginator->paginate($req, array(), $sortlist));