### PR TITLE
RCIAM-472_Enable_send_Petition_Confirmation_Email_via_COmanage_REST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Apply VO specific Terms & Conditions when enrolling to the VO
 - Added configuration option to skip email verification during Enrollment if a non empty voPersonVerified email attribute is provided
 - Added configuration option to customize the list of actions available on the top right corner of the OrgIdentity tab in COPerson's canvas
+- Added resend email invitation via REST API
 
 ### Changed
 - Update email and subject DN when the user logs into registry

--- a/app/View/CoPetitions/json/resend.ctp
+++ b/app/View/CoPetitions/json/resend.ctp
@@ -1,0 +1,38 @@
+<?php
+/**
+ * COmanage Registry CoPetition JSON resend View
+ *
+ * Portions licensed to the University Corporation for Advanced Internet
+ * Development, Inc. ("UCAID") under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * UCAID licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @link          http://www.internet2.edu/comanage COmanage Project
+ * @package       registry
+ * @since         COmanage Registry v0.1
+ * @license       Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ */
+
+// Get a pointer to our model
+$model = $this->name;                     // Unlike in the controllers, this is CamelPlural
+$req = Inflector::singularize($model);
+$modelpl = Inflector::tableize($req);
+$modelcc = $model;
+
+$response = !empty($vv_response) ? $vv_response : array();
+
+print json_encode(array("ResponseType" => $modelcc,
+    "Version" => "1.0",    // XXX this needs to be set by the controller
+    $modelcc => $response)) . "\n";

--- a/app/View/CoPetitions/xml/resend.ctp
+++ b/app/View/CoPetitions/xml/resend.ctp
@@ -1,0 +1,27 @@
+<?php
+/**
+ * COmanage Registry CoPetition XML resend View
+ *
+ * Portions licensed to the University Corporation for Advanced Internet
+ * Development, Inc. ("UCAID") under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * UCAID licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @link          http://www.internet2.edu/comanage COmanage Project
+ * @package       registry
+ * @since         COmanage Registry v0.1
+ * @license       Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ */
+


### PR DESCRIPTION
## Enable `/co_petitions/resend` action via REST API
Request to resend the invitation for the CO Petition with ID `1234`

### Example Request
`curl -u "user:password" "https://example.com/registry/co_petitions/resend/1234.json" | python -m json.tool`
### Example Response
```bash
{
    "CoPetitions": {
        "recipient": "john.doe@example.com",
        "status": "Invitation sent to john.doe@example.com"
    },
    "ResponseType": "CoPetitions",
    "Version": "1.0"
}
```