### PR TITLE
Expiration_policies_condition_run_every_xxdays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 
+### Added
+
+- Run Expiration Policies every xx days for each User
+
+### Fixed
+
+- Ldap Provisioner: Make Attribute Scope field for eduPersonUniqueId as an optional field
+
+## [3.2.3-rciam] - 2021-09-06
+
 ### Fixed
 
 - COU administrators get permission denied when filtering COU population
-- Ldap Provisioner: Make Attribute Scope field for eduPersonUniqueId as an optional field
 
 ## [3.2.2-rciam] - 2021-09-06
 

--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -945,6 +945,7 @@
     <field name="cond_before_expiry" type="I" />
     <field name="cond_after_expiry" type="I" />
     <field name="cond_count" type="I" />
+    <field name="cond_every_xdays" type="I" />
     <field name="cond_status" type="C" size="2" />
     <field name="cond_sponsor_invalid" type="L" />
     <field name="cond_any_cou" type="L" />
@@ -1018,6 +1019,38 @@
     </index>
   </table>
   
+  <table name="co_expiration_days_counts">
+    <field name="id" type="I">
+      <key />
+      <autoincrement />
+    </field>
+    <field name="co_expiration_policy_id" type="I">
+      <notnull />
+      <constraint>REFERENCES cm_co_expiration_policies(id)</constraint>
+    </field>
+    <field name="co_person_role_id" type="I">
+      <notnull />
+      <constraint>REFERENCES cm_co_person_roles(id)</constraint>
+    </field>
+    <field name="expiration_date_run" type="T" />
+    <field name="created" type="T" />
+    <field name="modified" type="T" />
+    <field name="co_expiration_days_count_id" type="I">
+      <constraint>REFERENCES cm_co_expiration_days_counts(id)</constraint>
+    </field>
+    <field name="revision" type="I" />
+    <field name="deleted" type="L" />
+    <field name="actor_identifier" type="C" size="256" />
+
+    <index name="co_expiration_days_counts_i1">
+      <col>co_expiration_policy_id</col>
+      <col>co_person_role_id</col>
+    </index>
+    <index name="co_expiration_days_counts_i2">
+      <col>co_expiration_count_id</col>
+    </index>
+  </table>
+
   <table name="co_notifications">
     <field name="id" type="I">
       <key />

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1800,6 +1800,8 @@ original notification at
   'fd.xp.count.cond.desc' => 'This Expiration Policy will apply up to the specified number of times',
   'fd.xp.disable' => 'Disable Expiration',
   'fd.xp.disable.desc' => 'Disable automatic (scheduled) expirations<br />This setting does not impact manual expirations',
+  'fd.xp.every_xday.cond' => 'Run policy every XX days',
+  'fd.xp.every_xday.cond.desc' => 'This Expiration Policy will apply every XX days.',
   'fd.xp.notify_coadmin.act' => 'Notify CO Administrator(s)',
   'fd.xp.notify_coadmin.act.desc' => 'The CO Administrator(s) will be notified when this Expiration Policy is applied',
   'fd.xp.notify_cogroup.act' => 'Notify CO Group',

--- a/app/Model/CoExpirationDaysCount.php
+++ b/app/Model/CoExpirationDaysCount.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * COmanage Registry CO Expiration Count Model
+ *
+ * Portions licensed to the University Corporation for Advanced Internet
+ * Development, Inc. ("UCAID") under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * UCAID licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @link          http://www.internet2.edu/comanage COmanage Project
+ * @package       registry-plugin
+ * @since         COmanage Registry v2.0.0
+ * @license       Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ */
+
+class CoExpirationDaysCount extends AppModel {
+  // Define class name for cake
+  public $name = "CoExpirationDaysCount";
+
+  // Add behaviors
+  public $actsAs = array('Containable',
+                         'Changelog' => array('priority' => 5));
+
+
+  // Association rules from this model to other models
+  public $belongsTo = array(
+    "CoExpirationPolicy",
+    "CoPersonRole"
+  );
+
+  // Default display field for cake generated views
+  public $displayField = "co_expiration_policy_id";
+
+  // Validation rules for table elements
+  public $validate = array(
+    'co_expiration_policy_id' => array(
+      'rule' => 'numeric',
+      'required' => true,
+      'allowEmpty' => false
+    ),
+    'co_person_role_id' => array(
+      'rule' => 'numeric',
+      'required' => true,
+      'allowEmpty' => false
+    ),
+    'expiration_date_run' => array(
+      'rule' => 'datetime',
+      'required' => true,
+      'allowEmpty' => false
+    )
+  );
+
+  /**
+   * Set expiration_date_run to zero(0)
+   *
+   * @param $coExpirationPolicyId     CoExpirationPolicy ID
+   * @param $coPersonRoleId           CoPerson Role ID
+   * @throws Exception
+   */
+  public function date_store($coExpirationPolicyId, $coPersonRoleId) {
+    $dbc = $this->getDataSource();
+    $dbc->begin();
+
+    // We don't currently try to validate either foreign key.
+    $args = array();
+    $args['conditions']['CoExpirationDaysCount.co_expiration_policy_id'] = $coExpirationPolicyId;
+    $args['conditions']['CoExpirationDaysCount.co_person_role_id'] = $coPersonRoleId;
+    $args['contain'] = false;
+
+    $days_count = $this->find('first', $args);
+    $this->clear();
+
+    if(!empty($days_count)) {
+      $this->id = $days_count['CoExpirationDaysCount']['id'];
+      $this->saveField('expiration_date_run', date('Y-m-d H:i:s'));
+    } else {
+      $exp_run = array(
+        'co_expiration_policy_id' => $coExpirationPolicyId,
+        'co_person_role_id'       => $coPersonRoleId,
+        'expiration_date_run'     => date('Y-m-d H:i:s')
+      );
+
+      $this->save($exp_run);
+    }
+
+    $dbc->commit();
+  }
+
+  /**
+   * Calculate the days passed since last notification sent
+   *
+   * @param Integer $coExpirationPolicyId CO Expiration Policy ID
+   * @param Integer $coPersonRoleId CO Person Role ID
+
+   * @return Integer|null Days passed, null in case never ran before
+   */
+
+  public function days_diff($coExpirationPolicyId, $coPersonRoleId) {
+    // We don't currently try to validate either foreign key.
+    $args = array();
+    $args['conditions']['CoExpirationDaysCount.co_expiration_policy_id'] = $coExpirationPolicyId;
+    $args['conditions']['CoExpirationDaysCount.co_person_role_id'] = $coPersonRoleId;
+    $args['contain'] = false;
+
+    $days_count = $this->find('first', $args);
+
+    if(isset($days_count) && !empty($days_count['CoExpirationDaysCount']['expiration_date_run'])) {
+      $run_date = new DateTime($days_count['CoExpirationDaysCount']['expiration_date_run']);
+      $now_date = new DateTime();
+      $diff_date = (array) date_diff($now_date, $run_date);
+      // The difference in days
+      return $diff_date['d'];
+    }
+
+    return null;
+  }
+}

--- a/app/Model/CoPersonRole.php
+++ b/app/Model/CoPersonRole.php
@@ -62,6 +62,7 @@ class CoPersonRole extends AppModel {
     // A person can have one or more address
     "Address" => array('dependent' => true),
     "CoExpirationCount" => array('dependent' => true),
+    "CoExpirationDaysCount" => array('dependent' => true),
     "CoPetition" => array(
       'dependent' => true,
       'foreignKey' => 'enrollee_co_person_role_id'

--- a/app/View/CoExpirationPolicies/fields.inc
+++ b/app/View/CoExpirationPolicies/fields.inc
@@ -292,6 +292,20 @@
           <li>
             <div class="field-name">
               <div class="field-title">
+                <?php print ($e ? $this->Form->label('cond_every_xdays', _txt('fd.xp.every_xday.cond')) : _txt('fd.xp.every_xday.cond')); ?>
+              </div>
+              <div class="field-desc"><?php print _txt('fd.xp.every_xday.cond.desc'); ?></div>
+            </div>
+            <div class="field-info">
+              <?php
+              print ($e ? $this->Form->input('cond_every_xdays', $args)
+                : filter_var($co_expiration_policies[0]['CoExpirationPolicy']['cond_every_xdays'],FILTER_SANITIZE_SPECIAL_CHARS));
+              ?>
+            </div>
+          </li>
+          <li>
+            <div class="field-name">
+              <div class="field-title">
                 <?php print ($e ? $this->Form->label('cond_status', _txt('fd.status')) : _txt('fd.status')); ?>
               </div>
               <div class="field-desc"><?php print _txt('fd.xp.status.cond.desc'); ?></div>


### PR DESCRIPTION
Add configuration param to Expiration policies.
Allow run ever xx days.

```sql
create table cm_co_expiration_days_counts
(
    id                      serial  not null constraint cm_co_expiration_days_counts_pkey primary key,
    co_expiration_policy_id integer not null
        constraint cm_co_expiration_days_counts_co_expiration_policy_id_fkey
            references cm_co_expiration_policies,
    co_person_role_id       integer not null
        constraint cm_co_expiration_days_counts_co_person_role_id_fkey
            references cm_co_person_roles,
    expiration_date_run         timestamp,
    created                 timestamp,
    modified                timestamp,
    co_expiration_days_count_id  integer
        constraint cm_co_expiration_days_counts_co_expiration_days_count_id_fkey
            references cm_co_expiration_days_counts,
    revision                integer,
    deleted                 boolean,
    actor_identifier        varchar(256)
);

create index cm_co_expiration_days_counts_i1
    on cm_co_expiration_days_counts (co_expiration_policy_id, co_person_role_id);

create index cm_co_expiration_days_counts_i2
    on cm_co_expiration_days_counts (co_expiration_days_count_id);
```

`cm_co_expiration_policies`
```sql
alter table cm_co_expiration_policies add column cond_every_xdays integer;
```